### PR TITLE
078: audio routes with host-selected models and measured usage

### DIFF
--- a/cmd/infercat/audio_test.go
+++ b/cmd/infercat/audio_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/infercat/infercat/internal/admin"
+	"github.com/infercat/infercat/internal/keys"
+	"github.com/infercat/infercat/internal/upstream"
+	"github.com/infercat/infercat/internal/usage"
+)
+
+func TestAudioFlagsReloadAndStatus(t *testing.T) {
+	dir, err := os.MkdirTemp("", "ic078-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+	var healthy atomic.Bool
+	healthy.Store(true)
+	engine := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !healthy.Load() {
+			http.Error(w, "offline", 503)
+			return
+		}
+		if r.URL.Path == "/v1/models" {
+			_, _ = io.WriteString(w, `{"data":[{"id":"m"}]}`)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer engine.Close()
+	gw := newFakeGateway()
+	plat := testPlatform(fakeAddr, nil)
+	plat.startTunnel = func(context.Context, tunnelOptions) (tunnelServer, error) { return fakeTunnel{}, nil }
+	var audio upstream.AudioEngine
+	plat.newGateway = func(o gatewayOptions, _ upstream.Upstream, _ keys.Store, _ usage.Recorder, _ func(string, ...any)) (gatewayServer, error) {
+		audio = o.Transcribe
+		if o.Speech == nil || o.MaxTranscriptionSeconds != 45 || o.TranscribeModel != "asr-model" || o.SpeechModel != "tts-model" {
+			t.Error("audio config did not reach gateway")
+		}
+		return gw, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var out, errw lockedBuffer
+	done := make(chan int, 1)
+	go func() {
+		done <- run(ctx, []string{"serve", "--console", "off", "--data-dir", dir, "--upstream", engine.URL, "--upstream-transcribe", engine.URL, "--upstream-transcribe-key", "asr-key", "--upstream-speech", engine.URL, "--upstream-speech-key", "tts-key", "--max-transcription-seconds", "45", "--upstream-transcribe-model", "asr-model", "--upstream-speech-model", "tts-model"}, &out, &errw, nil, false, plat)
+	}()
+	select {
+	case <-gw.serving:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("serve not ready: %s", errw.String())
+	}
+	cfg, err := loadConfig(dir)
+	if err != nil || cfg.UpstreamTranscribe != engine.URL || cfg.UpstreamSpeechKey != "tts-key" || cfg.MaxTranscriptionSeconds != 45 || cfg.UpstreamTranscribeModel != "asr-model" || cfg.UpstreamSpeechModel != "tts-model" {
+		t.Fatalf("remembered config %+v %v", cfg, err)
+	}
+	fi, _ := os.Stat(configPath(dir))
+	if fi.Mode().Perm() != 0600 {
+		t.Fatal("bearer config permissions")
+	}
+	if !audio.Info().Health.OK {
+		t.Fatal("initial audio probe failed")
+	}
+	healthy.Store(false)
+	if err := admin.Reload(context.Background(), dir); err == nil {
+		t.Fatal("reload hid failed probes")
+	}
+	if audio.Info().Health.OK {
+		t.Fatal("reload did not re-probe")
+	}
+	healthy.Store(true)
+	if err := admin.Reload(context.Background(), dir); err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if code := <-done; code != 0 {
+		t.Fatalf("serve exit %d %s", code, errw.String())
+	}
+	if !strings.Contains(out.String(), "/v1/audio/transcriptions") || !strings.Contains(out.String(), "/v1/audio/speech") {
+		t.Fatal("banner omitted routes")
+	}
+	if strings.Contains(out.String()+errw.String(), "asr-key") || strings.Contains(out.String()+errw.String(), "tts-key") {
+		t.Fatal("banner exposed engine keys")
+	}
+}
+func TestAudioKeyFlags(t *testing.T) {
+	dir := t.TempDir()
+	plat := testPlatform(fakeAddr, nil)
+	r := exec(t, plat, "keys", "add", "audio", "--daily-audio-seconds", "15", "--daily-speech-chars", "20", "--data-dir", dir)
+	if r.code != 0 {
+		t.Fatalf("add %d %s", r.code, r.err)
+	}
+	s, err := keys.NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	k, err := s.Find(context.Background(), "audio")
+	if err != nil || k.Limits.DailyAudioSeconds != 15 || k.Limits.DailySpeechChars != 20 {
+		t.Fatal("limits flags not stored")
+	}
+	r = exec(t, plat, "keys", "list", "--data-dir", dir)
+	if !strings.Contains(r.out, "AUDIO S/DAY") || !strings.Contains(r.out, "SPEECH CHARS/DAY") {
+		t.Fatal("keys list lacks audio limits")
+	}
+}

--- a/cmd/infercat/config.go
+++ b/cmd/infercat/config.go
@@ -20,16 +20,23 @@ const configName = "config.json"
 // Keys a newer build no longer knows (queue_timeout, request_timeout, max_body, retired by ticket
 // 010) are ignored on load and dropped on the next save.
 type config struct {
-	Models      string `json:"models,omitempty"`
-	Console     string `json:"console,omitempty"`
-	Upstream    string `json:"upstream,omitempty"`
-	UpstreamKey string `json:"upstream_key,omitempty"`
-	Slots       int    `json:"slots,omitempty"`
-	DevListen   string `json:"dev_listen,omitempty"`
-	DERPMapURL  string `json:"derpmap_url,omitempty"`
-	Region      string `json:"region,omitempty"`
-	Name        string `json:"name,omitempty"`
-	WebURL      string `json:"web_url,omitempty"`
+	UpstreamTranscribeModel string `json:"upstream_transcribe_model,omitempty"`
+	UpstreamSpeechModel     string `json:"upstream_speech_model,omitempty"`
+	UpstreamTranscribe      string `json:"upstream_transcribe,omitempty"`
+	UpstreamTranscribeKey   string `json:"upstream_transcribe_key,omitempty"`
+	UpstreamSpeech          string `json:"upstream_speech,omitempty"`
+	UpstreamSpeechKey       string `json:"upstream_speech_key,omitempty"`
+	MaxTranscriptionSeconds int    `json:"max_transcription_seconds,omitempty"`
+	Models                  string `json:"models,omitempty"`
+	Console                 string `json:"console,omitempty"`
+	Upstream                string `json:"upstream,omitempty"`
+	UpstreamKey             string `json:"upstream_key,omitempty"`
+	Slots                   int    `json:"slots,omitempty"`
+	DevListen               string `json:"dev_listen,omitempty"`
+	DERPMapURL              string `json:"derpmap_url,omitempty"`
+	Region                  string `json:"region,omitempty"`
+	Name                    string `json:"name,omitempty"`
+	WebURL                  string `json:"web_url,omitempty"`
 }
 
 // webURL is where this host's friends open the web app: the remembered --web-url, else the

--- a/cmd/infercat/keys.go
+++ b/cmd/infercat/keys.go
@@ -48,7 +48,7 @@ func (e *env) cmdKeys(ctx context.Context, pre string, args []string) error {
 	}
 }
 
-// limitFlags registers the seven limit flags and returns a reader that applies only the ones the
+// limitFlags registers the nine limit flags and returns a reader that applies only the ones the
 // host actually typed, so `keys limits ID --rpm 60` leaves everything else alone.
 func limitFlags(fs *flag.FlagSet) func(base keys.Limits) keys.Limits {
 	rpm := fs.Int("rpm", 0, "requests per minute")
@@ -57,6 +57,8 @@ func limitFlags(fs *flag.FlagSet) func(base keys.Limits) keys.Limits {
 	outTok := fs.Int("max-output-tokens", 0, "clamp on max_tokens")
 	maxCtx := fs.Int("max-context", 0, "context ceiling; 0 = the upstream's")
 	daily := fs.Int("daily-tokens", 0, "tokens per UTC day")
+	audio := fs.Int("daily-audio-seconds", 0, "transcription seconds per UTC day")
+	speech := fs.Int("daily-speech-chars", 0, "speech Unicode code points per UTC day")
 	models := fs.String("models", "", "comma-separated model allowlist; empty = every model")
 	return func(l keys.Limits) keys.Limits {
 		fs.Visit(func(f *flag.Flag) {
@@ -71,6 +73,10 @@ func limitFlags(fs *flag.FlagSet) func(base keys.Limits) keys.Limits {
 				l.MaxOutputTokens = *outTok
 			case "max-context":
 				l.MaxContext = *maxCtx
+			case "daily-audio-seconds":
+				l.DailyAudioSeconds = *audio
+			case "daily-speech-chars":
+				l.DailySpeechChars = *speech
 			case "daily-tokens":
 				l.DailyTokens = *daily
 			case "models":
@@ -275,11 +281,11 @@ func (e *env) keysList(ctx context.Context, pre string, args []string) error {
 	}
 	seen := rep.LastSeen()
 	tw := tabwriter.NewWriter(e.out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tNAME\tSTATUS\tRPM\tTPM\tDAILY\tCREATED\tLAST SEEN")
+	fmt.Fprintln(tw, "ID\tNAME\tSTATUS\tRPM\tTPM\tDAILY\tAUDIO S/DAY\tSPEECH CHARS/DAY\tCREATED\tLAST SEEN")
 	for _, k := range list {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			k.ID, k.Name, k.Status,
-			limitNum(k.Limits.RPM), limitNum(k.Limits.TPM), limitNum(k.Limits.DailyTokens),
+			limitNum(k.Limits.RPM), limitNum(k.Limits.TPM), limitNum(k.Limits.DailyTokens), limitNum(k.Limits.DailyAudioSeconds), limitNum(k.Limits.DailySpeechChars),
 			k.CreatedAt.Local().Format("2006-01-02"), ago(seen[k.ID]))
 	}
 	return tw.Flush()
@@ -470,6 +476,8 @@ Limit flags:
   --max-output-tokens N   clamp on max_tokens
   --max-context N         context ceiling (0 = the upstream's)
   --daily-tokens N        tokens per UTC day
+  --daily-audio-seconds N transcription seconds per UTC day (default 3600)
+  --daily-speech-chars N  speech code points per UTC day (default 200000)
   --models a,b            model allowlist (empty = every model); the host pin still applies
 
 Other flags:

--- a/cmd/infercat/main.go
+++ b/cmd/infercat/main.go
@@ -58,7 +58,10 @@ type gatewayServer interface {
 }
 
 type gatewayOptions struct {
-	ModelsPinned []string
+	Transcribe, Speech           upstream.AudioEngine
+	TranscribeModel, SpeechModel string
+	MaxTranscriptionSeconds      float64
+	ModelsPinned                 []string
 
 	LogPrompts  bool
 	HostName    string

--- a/cmd/infercat/serve.go
+++ b/cmd/infercat/serve.go
@@ -58,6 +58,13 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 	fs.String("data-dir", dataDir, dataDirUsage)
 	upURL := fs.String("upstream", cfg.Upstream, "inference server URL; detected when empty")
 	upKey := fs.String("upstream-key", cfg.UpstreamKey, "bearer token for the inference server")
+	transcribeModel := fs.String("upstream-transcribe-model", cfg.UpstreamTranscribeModel, "host's default transcription model")
+	speechModel := fs.String("upstream-speech-model", cfg.UpstreamSpeechModel, "host's default speech model")
+	transcribeURL := fs.String("upstream-transcribe", cfg.UpstreamTranscribe, "explicit OpenAI transcription engine URL")
+	transcribeKey := fs.String("upstream-transcribe-key", cfg.UpstreamTranscribeKey, "transcription engine bearer")
+	speechURL := fs.String("upstream-speech", cfg.UpstreamSpeech, "explicit OpenAI speech engine URL")
+	speechKey := fs.String("upstream-speech-key", cfg.UpstreamSpeechKey, "speech engine bearer")
+	maxAudio := fs.Int("max-transcription-seconds", intOr(cfg.MaxTranscriptionSeconds, 300), "maximum measured duration and unknown-duration reservation")
 	models := fs.String("models", cfg.Models, "comma-separated host model pin; all forgets it")
 	slots := fs.Int("slots", cfg.Slots, "parallel requests the engine can serve; 0 asks the engine")
 	logPrompts := fs.Bool("log-prompts", false, "record prompts and completions in usage.jsonl (off by default; not remembered)")
@@ -73,6 +80,17 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 		return err
 	}
 
+	if *maxAudio <= 0 {
+		return errors.New("--max-transcription-seconds must be positive")
+	}
+	transcribe, err := upstream.OpenAudio(ctx, *transcribeURL, *transcribeKey)
+	if err != nil {
+		return err
+	}
+	speech, err := upstream.OpenAudio(ctx, *speechURL, *speechKey)
+	if err != nil {
+		return err
+	}
 	consoleListener, err := admin.ListenConsole(*consoleAddr)
 	if err != nil {
 		return err
@@ -89,6 +107,8 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 	*upURL = forgetIfAuto(*upURL)
 	if err := saveConfig(dataDir, config{
 		Upstream: *upURL, UpstreamKey: *upKey, Slots: *slots, Models: strings.Join(pinned, ","),
+		UpstreamTranscribeModel: *transcribeModel, UpstreamSpeechModel: *speechModel,
+		UpstreamTranscribe: *transcribeURL, UpstreamTranscribeKey: *transcribeKey, UpstreamSpeech: *speechURL, UpstreamSpeechKey: *speechKey, MaxTranscriptionSeconds: *maxAudio,
 		DevListen: *devListen, DERPMapURL: *derpMapURL,
 		Region: *region, Name: *name, WebURL: *webURLFlag, Console: *consoleAddr,
 	}); err != nil {
@@ -145,11 +165,13 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 	}
 
 	gw, err := e.plat.newGateway(gatewayOptions{
-		ModelsPinned: pinned,
-		LogPrompts:   *logPrompts,
-		HostName:     hostName,
-		RelayRegion:  func() string { return tun.Status().Region },
-		DataDir:      dataDir, // today's counters are seeded from usage.jsonl there
+		ModelsPinned:    pinned,
+		TranscribeModel: *transcribeModel, SpeechModel: *speechModel,
+		Transcribe: transcribe, Speech: speech, MaxTranscriptionSeconds: float64(*maxAudio),
+		LogPrompts:  *logPrompts,
+		HostName:    hostName,
+		RelayRegion: func() string { return tun.Status().Region },
+		DataDir:     dataDir, // today's counters are seeded from usage.jsonl there
 	}, up, store, events, e.logf)
 	if err != nil {
 		return fmt.Errorf("gateway: %w", err)
@@ -165,8 +187,17 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 		st := buildStatus(ctx, started, tun, up, gw, store, tele)
 		st.Console = consoleAddress
 		st.ModelsPinned = pinned
+		st.Audio = audioStatus(transcribe, speech)
 		return st
-	}, store.Reload, events, e.consoleAPI(store, tun.Addr(), up, consoleSettings{
+	}, func() error {
+		err := store.Reload()
+		for _, a := range []upstream.AudioEngine{transcribe, speech} {
+			if a != nil {
+				err = errors.Join(err, a.Refresh(ctx))
+			}
+		}
+		return err
+	}, events, e.consoleAPI(store, tun.Addr(), up, consoleSettings{
 		Name: hostName, WebURL: webURL(config{WebURL: *webURLFlag}), Slots: *slots,
 		LogRequests: *logRequests, DataDir: dataDir, LogPrompts: *logPrompts,
 		Upstream: *upURL, DERPMapURL: *derpMapURL, Region: *region, ConfiguredWebURL: *webURLFlag,
@@ -181,6 +212,7 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 	}
 
 	e.printStartup(ctx, startup{
+		transcribe: transcribe, speech: speech,
 		tun: tun, up: up, store: store, dataDir: dataDir, consoleAddr: consoleAddress, pinned: pinned,
 		hostName: hostName, webURL: webURL(config{WebURL: *webURLFlag}), newIdentity: newIdentity,
 	})
@@ -317,15 +349,16 @@ func refreshLoop(ctx context.Context, up upstream.Upstream, logf func(string, ..
 // startup is everything the banner names. It is a struct because the banner grew the four lines
 // the strangers asked for (web, name, access, data) and a positional list of seven was worse.
 type startup struct {
-	pinned      []string
-	consoleAddr string
-	tun         tunnelServer
-	up          upstream.Upstream
-	store       keys.Store
-	dataDir     string
-	hostName    string
-	webURL      string
-	newIdentity bool // this run created host.key.json: explain the file, once
+	transcribe, speech upstream.AudioEngine
+	pinned             []string
+	consoleAddr        string
+	tun                tunnelServer
+	up                 upstream.Upstream
+	store              keys.Store
+	dataDir            string
+	hostName           string
+	webURL             string
+	newIdentity        bool // this run created host.key.json: explain the file, once
 }
 
 // printStartup writes the block docs the ticket fixes the order of: product, upstream, tunnel,
@@ -361,7 +394,17 @@ func (e *env) printStartup(ctx context.Context, s startup) {
 	if s.hostName != "" {
 		fmt.Fprintf(e.out, "name      %s  (shown to your friends)\n", s.hostName)
 	}
-	fmt.Fprintf(e.out, "access    friends reach only %s on %s\n", friendRoutes, info.URL)
+	routes := friendRoutes(s.transcribe != nil, s.speech != nil)
+	for _, route := range []string{"transcriptions", "speech"} {
+		if a, ok := audioStatus(s.transcribe, s.speech)[route]; ok {
+			fmt.Fprintf(e.out, "audio     /v1/audio/%s  %s  %s\n", route, a.URL, healthWord(a.Healthy, a.Since))
+		}
+	}
+	if s.transcribe == nil && s.speech == nil {
+		fmt.Fprintf(e.out, "access    friends reach only %s on %s\n", routes, info.URL)
+	} else {
+		fmt.Fprintf(e.out, "access    friends reach only %s (engines above)\n", routes)
+	}
 	fmt.Fprintf(e.out, "          nothing else on this machine — no other port, no files\n")
 	fmt.Fprintf(e.out, "data      %s\n", s.dataDir)
 	if s.consoleAddr != "" {
@@ -398,7 +441,16 @@ func (e *env) printStartup(ctx context.Context, s startup) {
 // friendRoutes is the whole of what the tunnel exposes, checked against internal/gateway's router
 // (request.go serve): /me and /healthz are answered by the gateway itself and never touch the
 // engine, so the sentence names the three routes that reach it.
-const friendRoutes = "/v1/models, /v1/chat/completions and /v1/embeddings"
+func friendRoutes(transcribe, speech bool) string {
+	routes := []string{"/v1/models", "/v1/chat/completions", "/v1/embeddings"}
+	if transcribe {
+		routes = append(routes, "/v1/audio/transcriptions")
+	}
+	if speech {
+		routes = append(routes, "/v1/audio/speech")
+	}
+	return strings.Join(routes[:len(routes)-1], ", ") + " and " + routes[len(routes)-1]
+}
 
 // telemetry is what the admin status reads beyond the seams' own snapshots (029): the event hub
 // for tokens per second, the sampled slot peak, and the host's display name.
@@ -577,6 +629,13 @@ Flags you pass are remembered in config.json, so the next serve needs none of th
 Ctrl-C drains in-flight requests for up to 10s, then stops.
 
 Flags:
+  --upstream-transcribe URL  explicit OpenAI transcription engine base URL
+  --upstream-transcribe-model ID  default model (otherwise first probed id)
+  --upstream-speech-model ID default model (otherwise first probed id)
+  --upstream-transcribe-key TOKEN  transcription engine bearer
+  --upstream-speech URL      explicit OpenAI speech engine base URL
+  --upstream-speech-key TOKEN speech engine bearer
+  --max-transcription-seconds N  measured upload ceiling / unknown reservation (default 300)
   --upstream URL          inference server; detected when absent, in the order
                           llama.cpp/llama-swap :8080, Ollama :11434, LM Studio :1234, vLLM :8000.
                           --upstream auto forgets a remembered URL and detects again
@@ -609,3 +668,14 @@ Flags:
 
 There is no daemon mode: run it under your supervisor of choice (launchd, systemd, tmux).
 `
+
+func audioStatus(transcribe, speech upstream.AudioEngine) map[string]admin.Upstream {
+	out := map[string]admin.Upstream{}
+	for route, a := range map[string]upstream.AudioEngine{"transcriptions": transcribe, "speech": speech} {
+		if a != nil {
+			i := a.Info()
+			out[route] = admin.Upstream{URL: i.URL, Healthy: i.Health.OK, Since: i.Health.Since, Slots: 1}
+		}
+	}
+	return out
+}

--- a/cmd/infercat/status.go
+++ b/cmd/infercat/status.go
@@ -181,6 +181,11 @@ func writeStatus(w io.Writer, st admin.Status) {
 	fmt.Fprintf(w, "upstream  %s  %s  %s  context %s  slots %d\n",
 		kindWord(st.Upstream.Kind), st.Upstream.URL, healthWord(st.Upstream.Healthy, st.Upstream.Since),
 		contextStr(st.Upstream.ModelContext), st.Upstream.Slots)
+	for _, route := range []string{"transcriptions", "speech"} {
+		if a, ok := st.Audio[route]; ok {
+			fmt.Fprintf(w, "audio     /v1/audio/%s  %s  %s\n", route, a.URL, healthWord(a.Healthy, a.Since))
+		}
+	}
 	if len(st.ModelsPinned) > 0 {
 		fmt.Fprintf(w, "models    %s (pinned)\n", modelList(st.ModelsPinned))
 	}

--- a/cmd/infercat/wire.go
+++ b/cmd/infercat/wire.go
@@ -42,11 +42,13 @@ func newPlatform() platform {
 		encodeInvite: invite.Encode,
 		newGateway: func(o gatewayOptions, up upstream.Upstream, store keys.Store, rec usage.Recorder, logf func(string, ...any)) (gatewayServer, error) {
 			return gateway.New(gateway.Config{
-				ModelsPinned: o.ModelsPinned,
-				LogPrompts:   o.LogPrompts,
-				HostName:     o.HostName,
-				RelayRegion:  o.RelayRegion,
-				DataDir:      o.DataDir,
+				ModelsPinned:    o.ModelsPinned,
+				TranscribeModel: o.TranscribeModel, SpeechModel: o.SpeechModel,
+				Transcribe: o.Transcribe, Speech: o.Speech, MaxTranscriptionSeconds: o.MaxTranscriptionSeconds,
+				LogPrompts:  o.LogPrompts,
+				HostName:    o.HostName,
+				RelayRegion: o.RelayRegion,
+				DataDir:     o.DataDir,
 			}, up, store, rec, logf), nil
 		},
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -120,7 +120,7 @@ Auth: `Authorization: Bearer <secret>` on every route except `/healthz`.
 | Route | Behaviour |
 |---|---|
 | `GET /healthz` | `{"ok":true}` always; no auth; no other info |
-| `GET /me` | `{key:{id,name,status}, limits:Limits, usage:{rpm_used, tpm_used, today_tokens, in_flight}, host:{name, upstream:{kind,healthy,model_context}, models:[ids], vision:{id:true|false|null}, relay:{region}, log_prompts:bool}}`. `kind` is `"unknown"` until an engine answered a signature probe; `healthy` reflects the last probe; the client discloses `log_prompts`. `vision` contains only invite-visible model ids and is refreshed with every probe (null = unknown); the app reads the selected model’s entry. llama.cpp reports `/props` modalities.vision, Ollama `/api/show` capabilities, LM Studio `/api/v0/models` type (`vlm`); vLLM assumes true on a successful model probe. Failed engine refreshes preserve prior state. Image-bearing requests refused by a 4xx naming images/multimodal input return `images_not_supported` (400, no retry) with the engine’s message, except context overflow retains its existing mapping. |
+| `GET /me` | `{key:{id,name,status}, limits:Limits, usage:{rpm_used, tpm_used, today_tokens, in_flight}, host:{name, upstream:{kind,healthy,model_context}, models:[ids], vision:{id:true|false|null}, audio:{transcriptions:model-id|null,speech:model-id|null}, relay:{region}, log_prompts:bool}}`. `kind` is `"unknown"` until an engine answered a signature probe; `healthy` reflects the last probe; the client discloses `log_prompts`. `vision` contains only invite-visible model ids and is refreshed with every probe (null = unknown); the app reads the selected model’s entry. llama.cpp reports `/props` modalities.vision, Ollama `/api/show` capabilities, LM Studio `/api/v0/models` type (`vlm`); vLLM assumes true on a successful model probe. Failed engine refreshes preserve prior state. Image-bearing requests refused by a 4xx naming images/multimodal input return `images_not_supported` (400, no retry) with the engine’s message, except context overflow retains its existing mapping. |
 | `GET /v1/models` | engine list filtered by the intersection of the host pin and the key's allowed models; per-key concurrency applies; **not counted against RPM** (ruled 2026-09-02, ticket 014: the friend's meter counts messages) |
 | `POST /v1/chat/completions` | stream and non-stream. Gateway MUST: flush every SSE chunk immediately; inject `stream_options.include_usage=true` when streaming; normalize the body once (strip engine-override aliases such as `n_predict`/`n`/`best_of`/`priority`, fill `model`, clamp `max_tokens` to the key's cap and shrink it to fit the context and the TPM/daily windows, floor 16); pass `reasoning_content` through untouched. An engine 400/422 caused by the request maps to 400 `invalid_request` with the engine's message — except a context overflow (llama.cpp `exceed_context_size_error`, vLLM "maximum context length"), which maps to 422 `context_too_long` so clients never retry it (036); 5xx → 502 |
 | `POST /v1/embeddings` | pass-through with auth + limits |
@@ -244,3 +244,40 @@ whitelisted display fields, including the runtime prompt-logging truth and confi
 web URL. Missing model context and historical uptime are not inferred. `make console-build`
 updates the embedded bundle; `make check` builds separately and refuses stale committed
 `console/dist` bytes without rewriting them.
+
+### Explicit audio engines
+
+`serve --upstream-transcribe URL --upstream-speech URL` adds the configured
+`POST /v1/audio/transcriptions` and `POST /v1/audio/speech` routes. Each base URL
+has a corresponding `-key` flag; both may point at the same OpenAI-compatible
+server. Flags and `--max-transcription-seconds` are remembered in the existing
+0600 config file. URL/key changes require the next `serve`; admin reload reloads
+keys and re-probes both audio engines. A successful `/v1/models` probe (or `/health`
+fallback) plus explicit configuration makes a route available when a model is known.
+`--upstream-transcribe-model` / `--upstream-speech-model` optionally select the
+host's default id; otherwise the first `/v1/models` id is used. A missing request
+model, or one not in that engine's list, becomes this default before allowlist
+checks. `/me.host.audio` contains `transcriptions` and `speech` model ids, or null
+when unavailable or not shared with this invite. A health-only engine needs an
+explicit model flag. Model flags are remembered and take effect on next serve.
+This states configured reachability, not inferred model capability. Native
+whisper.cpp `/inference` translation is not implemented.
+
+Audio uses the existing key authentication, key and host model allowlists,
+per-key RPM/concurrency, bounded global queue, body/read/first-byte/idle/write
+deadlines, and one final settlement path. It does not consume token budgets.
+Transcription file bytes and other fields are preserved while model and
+response_format are normalized (duplicate file/model/response_format fields are
+refused). Default/json requests ask the engine for verbose_json to obtain duration,
+then return only {"text"}; explicit verbose_json/text/srt/vtt retain their formats.
+Speech JSON values other than normalized model pass through and audio bytes
+are flushed as received, with no SSE framing. The transcription request cap is
+25 MiB; speech retains the ordinary 4 MiB cap.
+
+Usage JSONL adds `kind` (`transcription` or `speech`), `seconds`,
+`reserved_seconds`, `overrun_seconds`, `seconds_estimated`, and `characters` as
+applicable. Characters count Unicode code points. Neither audio nor transcription
+or speech text is written by the gateway, even with `--log-prompts`. Aggregate
+seconds/characters restore daily budgets on restart; unreadable or malformed
+usage history refuses audio rather than silently resetting its budget.
+`status` and the startup banner name both configured audio routes and engines.

--- a/docs/LIMITS.md
+++ b/docs/LIMITS.md
@@ -133,3 +133,45 @@ the owner of history, adds no host storage), not a stateful API.
   *chat-templated* prompt (~13+ tokens more); near the context ceiling a request the gateway admits is
   rejected by the engine as a raw `400`, shown to the friend as `invalid_request` instead of the true
   `422 context_too_long`, so the friend's client retries instead of shortening.
+
+## Audio budgets (078)
+
+`keys add` / `keys limits` accept `--daily-audio-seconds` (default 3600) and
+`--daily-speech-chars` (default 200000). Absent or zero legacy fields receive
+these defaults in memory; reading a key does not rewrite it. `keys list` shows
+both limits. Negative limits mean unlimited, as with the existing limits.
+Audio calls share per-key RPM/concurrency and the existing global engine queue;
+they do not spend tokens. Model allowlists and the host's model pin apply to audio
+model IDs too; include them in a host pin if using one.
+
+Before dispatch, transcription reserves measured duration from complete PCM or
+IEEE-float WAV headers, or FLAC STREAMINFO. Other containers (including MP3,
+OGG/Opus, and MP4/M4A in this slice), missing duration, or unparseable headers
+reserve `--max-transcription-seconds` (default 300). A measured upload above this
+ceiling is refused. Bytes are never called seconds. Speech reserves the number
+of Unicode code points in `input`. Live reservations count against the daily
+allowance so parallel requests cannot reserve the same remaining capacity.
+Insufficient room returns `audio_budget_exhausted` or `speech_budget_exhausted`
+(429, Retry-After to the next UTC midnight) before the engine is called.
+
+Default or `response_format=json` requests are sent upstream as `verbose_json`
+so the host can reconcile duration, then returned to the client as `{"text"}`.
+Explicit `verbose_json` is passed through. `text`, `srt`, and `vtt` responses
+have no duration metadata and charge the reservation (300 seconds for an
+unmeasurable upload, or its measured container duration), even for short clips.
+
+Before-dispatch failures release reservations. After dispatch, a complete
+transcription response's finite nonnegative `duration` is charged in full;
+otherwise the reservation is charged. Interrupted calls charge their reservation.
+Unknown-duration fallback charges set `seconds_estimated:true`. Speech charges
+its reserved characters after dispatch, including interrupted calls. The UTC day
+of settlement is used for both live charges and history replay.
+
+The bound for unmeasurable audio is on admission, not actual decoded duration:
+a file may exceed its policy reservation. Its full engine-reported duration is
+recorded as `seconds`, with the reservation in `reserved_seconds` and the excess
+in `overrun_seconds`. An overrun can put the day over budget; subsequent requests
+are refused until the next UTC day. Already-dispatched calls still settle in full.
+The host ceiling does not truncate audio or falsify the engine's measurement.
+For refused calls, `reserved_seconds` names the requested reservation, not a
+charge; `seconds` is zero/absent, and no reservation remains held.

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -32,7 +32,8 @@ var ErrNoDaemon = errors.New("no running host found for this data dir")
 // for `serve` and "bridge" for a `connect` given a data dir (ticket 029 promise 5): a bridge has
 // one session, its local endpoint under Upstream, and no keys.
 type Status struct {
-	ModelsPinned []string `json:"models_pinned,omitempty"`
+	Audio        map[string]Upstream `json:"audio,omitempty"`
+	ModelsPinned []string            `json:"models_pinned,omitempty"`
 
 	Console  string   `json:"console,omitempty"`
 	Product  string   `json:"product"`

--- a/internal/gateway/audio.go
+++ b/internal/gateway/audio.go
@@ -1,0 +1,367 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"math"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptrace"
+	"os"
+	"slices"
+	"strconv"
+	"sync/atomic"
+	"time"
+	"unicode/utf8"
+
+	"github.com/infercat/infercat/internal/keys"
+	"github.com/infercat/infercat/internal/upstream"
+)
+
+type audioRequest struct {
+	engine         upstream.AudioEngine
+	raw            []byte
+	contentType    string
+	dispatched     atomic.Bool
+	measured       bool
+	duration       *float64
+	chars          int
+	responseFormat string
+}
+
+func (q *request) proxyAudio(kind endpoint, engine upstream.AudioEngine) {
+	q.kind = kind
+	q.audio = &audioRequest{engine: engine}
+	q.ev.Kind = "transcription"
+	if kind == speechEndpoint {
+		q.ev.Kind = "speech"
+		q.ev.Stream = true
+	}
+	// n.stream stays false: a binary response must never receive SSE queue comments.
+	for _, stage := range []func() *gwError{q.audioHealth, q.admitKey, q.readAudio, q.reserveAudio, q.acquireSlot, q.callAudio, q.relayAudio} {
+		if err := stage(); err != nil {
+			if q.outcome == outcomeNone {
+				q.outcome = outcomeRejected
+			}
+			q.fail(err)
+			return
+		}
+	}
+	q.outcome = outcomeServed
+}
+func (q *request) audioHealth() *gwError {
+	if q.g.audioHistoryErr != nil {
+		return errf(CodeUpstreamDown, 1, "the host's audio usage history is unavailable")
+	}
+	if !q.audio.engine.Info().Health.OK {
+		return errf(CodeUpstreamDown, retryAfterUpstreamDown, "the host's audio engine is not answering")
+	}
+	return nil
+}
+func (q *request) readAudio() *gwError {
+	limit := q.g.maxBody
+	if q.kind == transcribeEndpoint {
+		limit = 25 << 20
+	}
+	if q.r.ContentLength > limit {
+		return errf(CodeBodyTooLarge, 0, "request body exceeds %d bytes", limit)
+	}
+	q.buffered = true
+	q.g.bodies.Add(1)
+	raw, err := io.ReadAll(http.MaxBytesReader(q.w, q.r.Body, limit))
+	if err != nil {
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			q.stalled = true
+		}
+		var big *http.MaxBytesError
+		if errors.As(err, &big) {
+			return errf(CodeBodyTooLarge, 0, "request body exceeds %d bytes", limit)
+		}
+		return errf(CodeInvalidRequest, 0, "audio body was not received completely")
+	}
+	_ = q.rc.SetReadDeadline(time.Time{})
+	q.audio.raw = raw
+	q.audio.contentType = q.r.Header.Get("Content-Type")
+	model := ""
+	if q.kind == speechEndpoint {
+		body, err := decodeObject(raw)
+		if err != nil {
+			return errf(CodeInvalidRequest, 0, "speech body must be a JSON object")
+		}
+		model, _ = body["model"].(string)
+		model = q.selectAudioModel(model)
+		body["model"] = model
+		input, ok := body["input"].(string)
+		if !ok || input == "" {
+			return errf(CodeInvalidRequest, 0, "speech input must be a nonempty string")
+		}
+		q.audio.chars = utf8.RuneCountInString(input)
+		q.audio.raw, _ = json.Marshal(body)
+		q.audio.contentType = "application/json"
+	} else {
+		typ, params, err := mime.ParseMediaType(q.audio.contentType)
+		if err != nil || typ != "multipart/form-data" || params["boundary"] == "" {
+			return errf(CodeInvalidRequest, 0, "transcription requires multipart/form-data")
+		}
+		reader := multipart.NewReader(bytes.NewReader(raw), params["boundary"])
+		haveFile, haveModel, haveFormat := false, false, false
+		var parts []struct {
+			part *multipart.Part
+			data []byte
+		}
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return errf(CodeInvalidRequest, 0, "invalid multipart audio body")
+			}
+			data, err := io.ReadAll(part)
+			if err != nil {
+				return errf(CodeInvalidRequest, 0, "invalid multipart audio field")
+			}
+			parts = append(parts, struct {
+				part *multipart.Part
+				data []byte
+			}{part, data})
+			switch part.FormName() {
+			case "response_format":
+				if haveFormat {
+					return errf(CodeInvalidRequest, 0, "duplicate response_format field")
+				}
+				haveFormat = true
+				q.audio.responseFormat = string(data)
+			case "model":
+				if haveModel {
+					return errf(CodeInvalidRequest, 0, "duplicate model field")
+				}
+				haveModel = true
+				model = string(data)
+			case "file":
+				if haveFile || len(data) == 0 {
+					return errf(CodeInvalidRequest, 0, "exactly one nonempty audio file is required")
+				}
+				haveFile = true
+				seconds, known := containerSeconds(data)
+				q.audio.measured = known
+				if !known {
+					seconds = q.g.cfg.MaxTranscriptionSeconds
+				}
+				if seconds > q.g.cfg.MaxTranscriptionSeconds {
+					return errf(CodeInvalidRequest, 0, "audio duration exceeds the host's %.3g second per-request ceiling", q.g.cfg.MaxTranscriptionSeconds)
+				}
+				q.ev.ReservedSeconds = seconds
+			}
+		}
+		if !haveFile {
+			return errf(CodeInvalidRequest, 0, "audio file is required")
+		}
+		model = q.selectAudioModel(model)
+		var rebuilt bytes.Buffer
+		writer := multipart.NewWriter(&rebuilt)
+		for _, item := range parts {
+			if item.part.FormName() == "model" || item.part.FormName() == "response_format" {
+				continue
+			}
+			dst, err := writer.CreatePart(item.part.Header)
+			if err != nil {
+				return errf(CodeInvalidRequest, 0, "invalid multipart audio field")
+			}
+			_, _ = dst.Write(item.data)
+		}
+		_ = writer.WriteField("model", model)
+		format := q.audio.responseFormat
+		if format == "" || format == "json" {
+			format = "verbose_json"
+		}
+		_ = writer.WriteField("response_format", format)
+		_ = writer.Close()
+		q.audio.raw, q.audio.contentType = rebuilt.Bytes(), writer.FormDataContentType()
+	}
+	if model == "" {
+		return errf(CodeUpstreamDown, retryAfterUpstreamDown, "the host has no audio model configured or reported")
+	}
+	if !q.key.AllowsModel(model) || (len(q.g.cfg.ModelsPinned) > 0 && !slices.Contains(q.g.cfg.ModelsPinned, model)) {
+		return errf(CodeModelNotAllowed, 0, "model is not shared with this invite")
+	}
+	q.ev.Model = model
+	return nil
+}
+
+// Explicit host choice wins the default; a health-only engine needs that choice.
+func audioModel(engine upstream.AudioEngine, configured string) *string {
+	if engine == nil || !engine.Info().Health.OK {
+		return nil
+	}
+	if configured != "" {
+		return &configured
+	}
+	for _, id := range engine.Info().Models {
+		if id != "" {
+			return &id
+		}
+	}
+	return nil
+}
+func (q *request) selectAudioModel(requested string) string {
+	if requested != "" && slices.Contains(q.audio.engine.Info().Models, requested) {
+		return requested
+	}
+	configured := q.g.cfg.TranscribeModel
+	if q.kind == speechEndpoint {
+		configured = q.g.cfg.SpeechModel
+	}
+	if model := audioModel(q.audio.engine, configured); model != nil {
+		return *model
+	}
+	return ""
+}
+func (q *request) reserveAudio() *gwError {
+	st := q.g.lim.state(q.key.ID)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	now := q.g.lim.now()
+	st.prune(now)
+	lim := keys.AudioDefaults(q.key.Limits)
+	retry := secondsUntil(st.day.Add(24*time.Hour), now)
+	if q.kind == transcribeEndpoint {
+		need := q.ev.ReservedSeconds
+		if lim.DailyAudioSeconds > 0 && st.audioSeconds+st.audioReserved+need > float64(lim.DailyAudioSeconds) {
+			return errf(CodeAudioBudgetExhausted, retry, "daily audio budget: %.3g seconds remaining; this request reserves %.3g", math.Max(0, float64(lim.DailyAudioSeconds)-st.audioSeconds-st.audioReserved), need)
+		}
+		q.adm.audioSeconds = need
+		st.audioReserved += need
+	} else {
+		need := q.audio.chars
+		if lim.DailySpeechChars > 0 && st.speechChars+st.speechReserved+need > lim.DailySpeechChars {
+			return errf(CodeSpeechBudgetExhausted, retry, "daily speech character budget is exhausted")
+		}
+		q.adm.speechChars = need
+		st.speechReserved += need
+	}
+	return nil
+}
+func (q *request) callAudio() *gwError {
+	ctx, cancel := context.WithCancel(q.r.Context())
+	q.cancelUpstream = cancel
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{WroteHeaders: func() { q.audio.dispatched.Store(true) }})
+	resp, err := q.audio.engine.AudioDo(ctx, string(q.kind), q.audio.contentType, q.audio.raw)
+	if err != nil {
+		q.outcome = outcomeEngineErr
+		if q.r.Context().Err() != nil {
+			q.outcome = outcomeCut
+		}
+		return q.upstreamErr(err)
+	}
+	q.resp = resp
+	return nil
+}
+func (q *request) relayAudio() *gwError {
+	q.idle = time.AfterFunc(q.g.idleTimeout, func() { q.engineIdle.Store(true); q.cancelUpstream() })
+	body := idleReader{r: q.resp.Body, t: q.idle, d: q.g.idleTimeout}
+	if q.kind == transcribeEndpoint || q.resp.StatusCode/100 != 2 {
+		raw, err := io.ReadAll(io.LimitReader(body, maxUpstreamBody+1))
+		if err != nil || len(raw) > maxUpstreamBody {
+			q.outcome = outcomeCut
+			return errf(CodeUpstreamError, 0, "audio engine response was incomplete or too large")
+		}
+		var measured struct {
+			Duration *float64 `json:"duration"`
+		}
+		if (q.audio.responseFormat == "" || q.audio.responseFormat == "json" || q.audio.responseFormat == "verbose_json") && json.Unmarshal(raw, &measured) == nil && measured.Duration != nil && *measured.Duration >= 0 && !math.IsNaN(*measured.Duration) && !math.IsInf(*measured.Duration, 0) {
+			q.audio.duration = measured.Duration
+		}
+		if q.resp.StatusCode/100 != 2 {
+			q.outcome = outcomeEngineErr
+			msg, _ := upstreamMessage(bytes.NewReader(raw))
+			if q.resp.StatusCode == 400 || q.resp.StatusCode == 422 {
+				return errf(CodeInvalidRequest, 0, "the host's audio engine rejected this request (HTTP %d): %s", q.resp.StatusCode, msg)
+			}
+			return errf(CodeUpstreamError, 0, "audio engine returned HTTP %d: %s", q.resp.StatusCode, msg)
+		}
+		if q.audio.responseFormat == "" || q.audio.responseFormat == "json" {
+			var result struct {
+				Text *string `json:"text"`
+			}
+			if json.Unmarshal(raw, &result) != nil || result.Text == nil {
+				q.outcome = outcomeEngineErr
+				return errf(CodeUpstreamError, 0, "audio engine returned invalid transcription JSON")
+			}
+			raw, _ = json.Marshal(result)
+			q.resp.Header.Set("Content-Type", "application/json")
+			q.resp.Header.Set("Content-Length", strconv.Itoa(len(raw)))
+		}
+		q.audioHead()
+		q.markTTFT()
+		if _, err := q.w.Write(raw); err != nil {
+			q.outcome = outcomeCut
+			return errf(CodeClientClosed, 0, "client went away")
+		}
+		return nil
+	}
+	q.audioHead()
+	buf := make([]byte, 32<<10)
+	for {
+		n, err := body.Read(buf)
+		if n > 0 {
+			q.markTTFT()
+			q.armWrite()
+			if _, werr := q.w.Write(buf[:n]); werr != nil {
+				q.outcome = outcomeCut
+				return errf(CodeClientClosed, 0, "client went away")
+			}
+			if ferr := q.rc.Flush(); ferr != nil {
+				q.outcome = outcomeCut
+				return errf(CodeClientClosed, 0, "client went away")
+			}
+		}
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			q.outcome = outcomeCut
+			return q.upstreamErr(err)
+		}
+	}
+}
+func (q *request) audioHead() {
+	for _, name := range []string{"Content-Type", "Content-Disposition", "Content-Length"} {
+		if v := q.resp.Header.Get(name); v != "" {
+			q.w.Header().Set(name, v)
+		}
+	}
+	q.writeHeader(q.resp.StatusCode)
+}
+
+// finish calls this exactly once, alongside the existing RPM/concurrency settlement.
+func (q *request) settleAudio() {
+	st := q.g.lim.state(q.key.ID)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	now := q.g.lim.now()
+	st.prune(now)
+	st.audioReserved -= q.adm.audioSeconds
+	st.speechReserved -= q.adm.speechChars
+	if !q.audio.dispatched.Load() {
+		return
+	}
+	q.ev.TS = now // charge and replay belong to the UTC day the call settles on.
+	if q.kind == speechEndpoint {
+		q.ev.Characters = q.adm.speechChars
+		st.speechChars += q.ev.Characters
+		return
+	}
+	q.ev.Seconds = q.adm.audioSeconds
+	q.ev.SecondsEstimated = !q.audio.measured
+	if q.audio.duration != nil && q.outcome != outcomeCut && q.r.Context().Err() == nil {
+		q.ev.Seconds = *q.audio.duration
+		q.ev.SecondsEstimated = false
+	}
+	q.ev.OverrunSeconds = math.Max(0, q.ev.Seconds-q.ev.ReservedSeconds)
+	st.audioSeconds += q.ev.Seconds
+}

--- a/internal/gateway/audio_duration.go
+++ b/internal/gateway/audio_duration.go
@@ -1,0 +1,55 @@
+package gateway
+
+import "encoding/binary"
+
+// containerSeconds reads duration without decoding or writing audio. Supported: PCM/float WAV
+// (validated frame/byte rates and complete data chunks), and FLAC STREAMINFO total samples.
+// Other or incomplete containers are unmeasurable and use the host's policy reservation.
+func containerSeconds(b []byte) (float64, bool) {
+	if len(b) >= 42 && string(b[:4]) == "fLaC" && b[4]&127 == 0 && b[5] == 0 && b[6] == 0 && b[7] == 34 {
+		bits := binary.BigEndian.Uint64(b[18:26])
+		rate := bits >> 44
+		samples := bits & ((1 << 36) - 1)
+		if rate > 0 && samples > 0 {
+			return float64(samples) / float64(rate), true
+		}
+	}
+	if len(b) < 12 || string(b[:4]) != "RIFF" || string(b[8:12]) != "WAVE" {
+		return 0, false
+	}
+	end := int64(binary.LittleEndian.Uint32(b[4:8])) + 8
+	if end > int64(len(b)) || end < 12 {
+		return 0, false
+	}
+	var byteRate, align, data uint64
+	for pos := int64(12); pos+8 <= end; {
+		size := int64(binary.LittleEndian.Uint32(b[pos+4 : pos+8]))
+		start := pos + 8
+		if start+size > end {
+			return 0, false
+		}
+		switch string(b[pos : pos+4]) {
+		case "fmt ":
+			if size < 16 {
+				return 0, false
+			}
+			f := b[start : start+size]
+			format := binary.LittleEndian.Uint16(f[:2])
+			channels := uint64(binary.LittleEndian.Uint16(f[2:4]))
+			rate := uint64(binary.LittleEndian.Uint32(f[4:8]))
+			bits := uint64(binary.LittleEndian.Uint16(f[14:16]))
+			align = uint64(binary.LittleEndian.Uint16(f[12:14]))
+			byteRate = uint64(binary.LittleEndian.Uint32(f[8:12]))
+			if (format != 1 && format != 3) || channels == 0 || rate == 0 || bits == 0 || bits%8 != 0 || align != channels*(bits/8) || byteRate != rate*align {
+				return 0, false
+			}
+		case "data":
+			data += uint64(size)
+		}
+		pos = start + size + (size % 2)
+	}
+	if byteRate == 0 || align == 0 || data == 0 || data%align != 0 {
+		return 0, false
+	}
+	return float64(data) / float64(byteRate), true
+}

--- a/internal/gateway/audio_test.go
+++ b/internal/gateway/audio_test.go
@@ -1,0 +1,515 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/infercat/infercat/internal/keys"
+	"github.com/infercat/infercat/internal/upstream"
+	"github.com/infercat/infercat/internal/usage"
+)
+
+func wave(seconds int) []byte {
+	b := make([]byte, 44+seconds*32000)
+	copy(b, "RIFF")
+	binary.LittleEndian.PutUint32(b[4:], uint32(len(b)-8))
+	copy(b[8:], "WAVEfmt ")
+	binary.LittleEndian.PutUint32(b[16:], 16)
+	binary.LittleEndian.PutUint16(b[20:], 1)
+	binary.LittleEndian.PutUint16(b[22:], 1)
+	binary.LittleEndian.PutUint32(b[24:], 16000)
+	binary.LittleEndian.PutUint32(b[28:], 32000)
+	binary.LittleEndian.PutUint16(b[32:], 2)
+	binary.LittleEndian.PutUint16(b[34:], 16)
+	copy(b[36:], "data")
+	binary.LittleEndian.PutUint32(b[40:], uint32(len(b)-44))
+	return b
+}
+func multipartAudio(t *testing.T, audio []byte) ([]byte, string) {
+	t.Helper()
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	_ = w.WriteField("model", "m1")
+	_ = w.WriteField("language", "en")
+	_ = w.WriteField("prompt", "PRIVATE PROMPT")
+	f, _ := w.CreateFormFile("file", "note.wav")
+	_, _ = f.Write(audio)
+	_ = w.Close()
+	return b.Bytes(), w.FormDataContentType()
+}
+func audioEngine(t *testing.T, handler http.HandlerFunc) (upstream.AudioEngine, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer engine-key" {
+			t.Error("engine bearer absent")
+		}
+		if r.URL.Path == "/v1/models" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"data":[{"id":"m1"}]}`)
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	engine, err := upstream.OpenAudio(context.Background(), server.URL, "engine-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return engine, server
+}
+func postAudio(t *testing.T, h *harness, path, ct string, b []byte) resp {
+	t.Helper()
+	req, _ := http.NewRequest("POST", h.srv.URL+path, bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	req.Header.Set("Content-Type", ct)
+	r, err := h.srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Body.Close()
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := resp{status: r.StatusCode, header: r.Header, body: raw}
+	var e errorBody
+	if json.Unmarshal(raw, &e) == nil {
+		out.errCode = e.Error.Code
+		out.errType = e.Error.Type
+		out.message = e.Error.Message
+		if out.errCode != "" {
+			seenCodesMu.Lock()
+			seenCodes[out.errCode] = true
+			seenCodesMu.Unlock()
+		}
+	}
+	return out
+}
+func TestAudioDurationHeaders(t *testing.T) {
+	if n, ok := containerSeconds(wave(10)); !ok || n != 10 {
+		t.Fatalf("WAV %v %v", n, ok)
+	}
+	flac := make([]byte, 43)
+	copy(flac, "fLaC")
+	flac[7] = 34
+	binary.BigEndian.PutUint64(flac[18:], uint64(48000)<<44|480000)
+	if n, ok := containerSeconds(flac); !ok || n != 10 {
+		t.Fatalf("FLAC %v %v", n, ok)
+	}
+	malformed := wave(10)
+	binary.LittleEndian.PutUint32(malformed[28:], 1)
+	for _, b := range [][]byte{[]byte("compressed"), wave(10)[:45], malformed} {
+		if _, ok := containerSeconds(b); ok {
+			t.Fatal("invalid/unknown header became measured")
+		}
+	}
+}
+func TestAudioReservationsAndUsage(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		body             []byte
+		budget           int
+		duration         float64
+		want             Code
+		charge, reserved float64
+	}{
+		{"measured", wave(10), 15, 10, "", 10, 10},
+		{"five", wave(10), 5, 10, CodeAudioBudgetExhausted, 0, 10},
+		{"unknown200", []byte("unmeasurable"), 200, 10, CodeAudioBudgetExhausted, 0, 300},
+		{"unknown400", []byte("unmeasurable"), 400, 10, "", 10, 300},
+		{"overrun", []byte("unmeasurable"), 400, 600, "", 600, 300},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, ct := multipartAudio(t, tc.body)
+			var calls atomic.Int32
+			engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if err := r.ParseMultipartForm(25 << 20); err != nil {
+					t.Fatal(err)
+				}
+				f, header, err := r.FormFile("file")
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer f.Close()
+				got, _ := io.ReadAll(f)
+				if !bytes.Equal(got, tc.body) || header.Filename != "note.wav" || r.FormValue("language") != "en" || r.FormValue("prompt") != "PRIVATE PROMPT" || r.FormValue("model") != "m1" || r.FormValue("response_format") != "verbose_json" {
+					t.Error("multipart values or reconciliation format wrong")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"text": "PRIVATE TRANSCRIPT", "duration": tc.duration})
+			})
+			h := newHarness(t, Config{Transcribe: engine, LogPrompts: true}, nil)
+			h.setKey(func(k *keys.Key) { k.Limits.DailyAudioSeconds = tc.budget })
+			r := postAudio(t, h, string(transcribeEndpoint), ct, raw)
+			if tc.want != "" {
+				h.expectErr(r, tc.want)
+				if calls.Load() != 0 || r.header.Get("Retry-After") == "" {
+					t.Fatal("budget refusal dispatched or omitted retry")
+				}
+			} else if r.status != 200 {
+				t.Fatalf("%d %s", r.status, r.body)
+			}
+			event := h.rec.waitFor(t, 1)[0]
+			if event.Seconds != tc.charge || event.ReservedSeconds != tc.reserved || event.Prompt != "" || event.Completion != "" {
+				t.Fatalf("event %+v", event)
+			}
+			if event.OverrunSeconds != max(0, tc.charge-tc.reserved) {
+				t.Fatal("overrun not recorded truthfully")
+			}
+			if h.gw.Counters(h.key.ID).TodayAudioSeconds != tc.charge {
+				t.Fatal("counter did not reconcile")
+			}
+			if tc.name == "measured" || tc.name == "overrun" {
+				h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeAudioBudgetExhausted)
+				if calls.Load() != 1 {
+					t.Fatal("second call reached engine")
+				}
+			}
+		})
+	}
+}
+func TestAudioSpeechStreamsAndChargesCodePoints(t *testing.T) {
+	gate := make(chan struct{})
+	defer close(gate)
+	engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+		var b map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&b)
+		if b["input"] != "你好🦊" || b["voice"] != "voice" {
+			t.Error("JSON values changed")
+		}
+		w.Header().Set("Content-Type", "audio/wav")
+		_, _ = w.Write([]byte("RIFF"))
+		w.(http.Flusher).Flush()
+		select {
+		case <-gate:
+		case <-r.Context().Done():
+		}
+	})
+	h := newHarness(t, Config{Speech: engine, LogPrompts: true}, nil)
+	h.setKey(func(k *keys.Key) { k.Limits.DailySpeechChars = 3 })
+	req, _ := http.NewRequest("POST", h.srv.URL+string(speechEndpoint), strings.NewReader(`{"model":"m1","input":"你好🦊","voice":"voice"}`))
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	r, err := h.srv.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := make([]byte, 4)
+	_, err = io.ReadFull(r.Body, first)
+	if err != nil || string(first) != "RIFF" || r.Header.Get("Content-Type") != "audio/wav" {
+		t.Fatalf("first audio bytes %q %v", first, err)
+	}
+	r.Body.Close()
+	ev := h.rec.waitFor(t, 1)[0]
+	if ev.Characters != 3 || ev.Prompt != "" || ev.Completion != "" {
+		t.Fatalf("partial speech settlement %+v", ev)
+	}
+	h.expectErr(h.post(string(speechEndpoint), `{"model":"m1","input":"a","voice":"voice"}`), CodeSpeechBudgetExhausted)
+}
+func TestAudioConcurrentReservations(t *testing.T) {
+	gate, entered := make(chan struct{}), make(chan struct{})
+	defer close(gate)
+	engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		select {
+		case <-gate:
+		case <-r.Context().Done():
+		}
+		_, _ = io.WriteString(w, `{"text":"hello","duration":10}`)
+	})
+	h := newHarness(t, Config{Transcribe: engine}, nil)
+	h.setKey(func(k *keys.Key) { k.Limits.MaxConcurrent = 2; k.Limits.DailyAudioSeconds = 400 })
+	raw, ct := multipartAudio(t, []byte("unknown"))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "POST", h.srv.URL+string(transcribeEndpoint), bytes.NewReader(raw))
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	req.Header.Set("Content-Type", ct)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r, _ := h.srv.Client().Do(req)
+		if r != nil {
+			r.Body.Close()
+		}
+	}()
+	<-entered
+	h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeAudioBudgetExhausted)
+	cancel()
+	<-done
+}
+func TestAudioRefusalsAndRestart(t *testing.T) {
+	var calls atomic.Int32
+	engine, server := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, `{"error":"This model maximum context length rejected PRIVATE AUDIO TEXT"}`, 400)
+	})
+	h := newHarness(t, Config{Transcribe: engine, MaxTranscriptionSeconds: 5}, nil)
+	raw, ct := multipartAudio(t, wave(10))
+	h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeInvalidRequest)
+	h.gw.cfg.MaxTranscriptionSeconds = 300
+	h.setKey(func(k *keys.Key) { k.Limits.Models = []string{"other"} })
+	h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeModelNotAllowed)
+	if calls.Load() != 0 {
+		t.Fatal("refusal reached engine")
+	}
+	h.setKey(func(k *keys.Key) { k.Limits.Models = nil })
+	server.Close()
+	h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeUpstreamDown)
+	if h.gw.Counters(h.key.ID).TodayAudioSeconds != 0 {
+		t.Fatal("dial failure was charged")
+	}
+	dir := t.TempDir()
+	event := usage.Event{TS: time.Now(), KeyID: h.key.ID, Endpoint: string(transcribeEndpoint), Seconds: 10}
+	b, _ := json.Marshal(event)
+	_ = os.WriteFile(filepath.Join(dir, usage.FileName), append(b, '\n'), 0600)
+	restored := New(Config{DataDir: dir}, h.up, h.store, nil, nil)
+	if restored.Counters(h.key.ID).TodayAudioSeconds != 10 {
+		t.Fatal("audio budget did not survive restart")
+	}
+}
+
+func TestAudioFailureChargingAndHistoryRefusal(t *testing.T) {
+	engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(400)
+		_, _ = io.WriteString(w, `{"error":"This model maximum context length rejected PRIVATE AUDIO TEXT"}`)
+	})
+	h := newHarness(t, Config{Transcribe: engine}, nil)
+	raw, ct := multipartAudio(t, wave(10))
+	h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeInvalidRequest)
+	event := h.rec.waitFor(t, 1)[0]
+	if event.Seconds != 10 || event.SecondsEstimated {
+		t.Fatalf("after-dispatch failure %+v", event)
+	}
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, usage.FileName), []byte("broken event\n"), 0600)
+	var logs logBuf
+	base := newHarness(t, Config{}, nil)
+	_ = New(Config{DataDir: dir, Transcribe: engine}, base.up, base.store, base.rec, logs.logf)
+	if !strings.Contains(logs.String(), "audio refused: usage history has 1 malformed rows") {
+		t.Fatal("missing startup refusal", logs.String())
+	}
+	bad := newHarness(t, Config{DataDir: dir, Transcribe: engine}, nil)
+	h.expectErr(postAudio(t, bad, string(transcribeEndpoint), ct, raw), CodeUpstreamDown)
+}
+func TestAudioCapabilityAndUnconfiguredRoutes(t *testing.T) {
+	engine, server := audioEngine(t, func(w http.ResponseWriter, r *http.Request) { http.NotFound(w, r) })
+	h := newHarness(t, Config{Transcribe: engine}, nil)
+	var me meResponse
+	_ = json.Unmarshal(h.get("/me").body, &me)
+	if me.Host.Audio.Transcriptions == nil || *me.Host.Audio.Transcriptions != "m1" || me.Host.Audio.Speech != nil {
+		t.Fatal("configured route capabilities wrong")
+	}
+	h.expectErr(h.post(string(speechEndpoint), `{}`), CodeNotFound)
+	server.Close()
+	_ = engine.Refresh(context.Background())
+	_ = json.Unmarshal(h.get("/me").body, &me)
+	if me.Host.Audio.Transcriptions != nil {
+		t.Fatal("unhealthy engine advertised")
+	}
+}
+
+func TestAudioBodyCapAndQueueRelease(t *testing.T) {
+	var calls atomic.Int32
+	engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) { calls.Add(1) })
+	h := newHarness(t, Config{Transcribe: engine}, nil)
+	req := httptest.NewRequest("POST", string(transcribeEndpoint), nil)
+	req.ContentLength = (25 << 20) + 1
+	req.Header.Set("Authorization", "Bearer "+testSecret)
+	response := httptest.NewRecorder()
+	h.gw.Handler().ServeHTTP(response, req)
+	if response.Code != 413 || calls.Load() != 0 {
+		t.Fatal("25 MiB body cap failed before dispatch")
+	}
+	if _, err := h.gw.queue.acquire(context.Background(), time.Second, time.Second, nil); err != nil {
+		t.Fatal(err)
+	}
+	defer h.gw.queue.release()
+	h.gw.queueTimeout = 5 * time.Millisecond
+	raw, ct := multipartAudio(t, wave(10))
+	h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeQueueTimeout)
+	counts := h.gw.Counters(h.key.ID)
+	if counts.TodayAudioSeconds != 0 || counts.InFlight != 0 || counts.RPMUsed != 1 || calls.Load() != 0 {
+		t.Fatalf("queue-lost settlement %+v calls=%d", counts, calls.Load())
+	}
+}
+
+func TestAudioBudgetRollsAtUTCMidnight(t *testing.T) {
+	engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"text":"hello","duration":10}`)
+	})
+	h := newHarness(t, Config{Transcribe: engine}, nil)
+	h.setKey(func(k *keys.Key) { k.Limits.DailyAudioSeconds = 15 })
+	now := time.Date(2026, 9, 9, 23, 59, 55, 0, time.UTC)
+	h.gw.lim.now = func() time.Time { return now }
+	raw, ct := multipartAudio(t, wave(10))
+	if r := postAudio(t, h, string(transcribeEndpoint), ct, raw); r.status != 200 {
+		t.Fatal(r.status)
+	}
+	r := postAudio(t, h, string(transcribeEndpoint), ct, raw)
+	h.expectErr(r, CodeAudioBudgetExhausted)
+	if r.header.Get("Retry-After") != "5" {
+		t.Fatalf("UTC retry: %s", r.header.Get("Retry-After"))
+	}
+	if ev := h.rec.waitFor(t, 2)[0]; !ev.TS.Equal(now) {
+		t.Fatal("event and charge use different UTC days")
+	}
+	now = now.Add(6 * time.Second)
+	if r := postAudio(t, h, string(transcribeEndpoint), ct, raw); r.status != 200 {
+		t.Fatal("new UTC day retained old charge")
+	}
+}
+
+func audioFields(t *testing.T, fields map[string]string) ([]byte, string) {
+	t.Helper()
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	for key, value := range fields {
+		_ = w.WriteField(key, value)
+	}
+	f, _ := w.CreateFormFile("file", "phone.mp3")
+	_, _ = f.Write([]byte("unmeasurable audio"))
+	_ = w.Close()
+	return b.Bytes(), w.FormDataContentType()
+}
+
+func TestAudioJSONReconcilesWithoutClientOptIn(t *testing.T) {
+	for _, format := range []string{"", "json", "verbose_json", "text", "srt", "vtt"} {
+		t.Run("format="+format, func(t *testing.T) {
+			wantFormat, response, charge := format, "plain transcript", float64(300)
+			if format == "" || format == "json" || format == "verbose_json" {
+				wantFormat, response, charge = "verbose_json", `{"text":"hello","duration":2.5,"segments":[]}`, 2.5
+			}
+			engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+				if err := r.ParseMultipartForm(1 << 20); err != nil {
+					t.Fatal(err)
+				}
+				if r.FormValue("response_format") != wantFormat || r.FormValue("model") != "m1" {
+					t.Error("wrong normalized fields", r.MultipartForm.Value)
+				}
+				w.Header().Set("Content-Type", "text/plain")
+				w.Header().Set("Content-Length", strconv.Itoa(len(response)))
+				_, _ = io.WriteString(w, response)
+			})
+			h := newHarness(t, Config{Transcribe: engine}, nil)
+			fields := map[string]string{}
+			if format != "" {
+				fields["response_format"] = format
+			}
+			raw, ct := audioFields(t, fields)
+			r := postAudio(t, h, string(transcribeEndpoint), ct, raw)
+			want := response
+			if format == "" || format == "json" {
+				want = `{"text":"hello"}`
+			}
+			if r.status != 200 || string(r.body) != want || r.header.Get("Content-Length") != strconv.Itoa(len(want)) {
+				t.Fatalf("response %d %q %v", r.status, r.body, r.header)
+			}
+			ev := h.rec.waitFor(t, 1)[0]
+			if ev.Seconds != charge || ev.ReservedSeconds != 300 || ev.SecondsEstimated != (charge == 300) {
+				t.Fatalf("settlement %+v", ev)
+			}
+			if format == "" {
+				// Thirteen short SDK-default clips cost their real duration, not a 3600 s day.
+				for range 12 {
+					if r := postAudio(t, h, string(transcribeEndpoint), ct, raw); r.status != 200 {
+						t.Fatalf("short clip refused: %d", r.status)
+					}
+				}
+				_ = h.rec.waitFor(t, 13)
+				if n := h.gw.Counters(h.key.ID).TodayAudioSeconds; n != 32.5 {
+					t.Fatalf("short clips charged %v", n)
+				}
+			}
+		})
+	}
+}
+
+func TestAudioHostModelSelection(t *testing.T) {
+	for _, kind := range []endpoint{transcribeEndpoint, speechEndpoint} {
+		for _, tc := range []struct{ name, configured, requested, want string }{
+			{"first", "", "", "m1"}, {"configured", "host-model", "", "host-model"},
+			{"unknown", "host-model", "chat-model", "host-model"}, {"listed", "host-model", "m1", "m1"},
+		} {
+			t.Run(string(kind)+tc.name, func(t *testing.T) {
+				var calls atomic.Int32
+				engine, _ := audioEngine(t, func(w http.ResponseWriter, r *http.Request) {
+					calls.Add(1)
+					var model string
+					if kind == speechEndpoint {
+						var b map[string]any
+						_ = json.NewDecoder(r.Body).Decode(&b)
+						model, _ = b["model"].(string)
+					} else {
+						_ = r.ParseMultipartForm(1 << 20)
+						model = r.FormValue("model")
+					}
+					if model != tc.want {
+						t.Errorf("model %q, want %q", model, tc.want)
+					}
+					_, _ = io.WriteString(w, `{"text":"hello","duration":1}`)
+				})
+				h := newHarness(t, Config{Transcribe: engine, Speech: engine, TranscribeModel: tc.configured, SpeechModel: tc.configured}, nil)
+				raw, ct := audioFields(t, map[string]string{"model": tc.requested})
+				if kind == speechEndpoint {
+					raw, _ = json.Marshal(map[string]string{"model": tc.requested, "input": "hello"})
+					ct = "application/json"
+				}
+				if r := postAudio(t, h, string(kind), ct, raw); r.status != 200 {
+					t.Fatalf("%d %s", r.status, r.body)
+				}
+				h.setKey(func(k *keys.Key) { k.Limits.Models = []string{"not-shared"} })
+				h.expectErr(postAudio(t, h, string(kind), ct, raw), CodeModelNotAllowed)
+				if calls.Load() != 1 {
+					t.Fatal("unshared selected model dispatched")
+				}
+				var me meResponse
+				_ = json.Unmarshal(h.get("/me").body, &me)
+				if me.Host.Audio.Transcriptions != nil || me.Host.Audio.Speech != nil {
+					t.Fatal("unshared capability advertised")
+				}
+			})
+		}
+	}
+}
+
+func TestAudioHealthOnlyRequiresHostModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			_, _ = io.WriteString(w, "ok")
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	engine, err := upstream.OpenAudio(context.Background(), server.URL, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if audioModel(engine, "") != nil {
+		t.Fatal("health-only engine advertised without model")
+	}
+	if model := audioModel(engine, "chosen"); model == nil || *model != "chosen" {
+		t.Fatal("host model was lost")
+	}
+	h := newHarness(t, Config{Transcribe: engine}, nil)
+	raw, ct := audioFields(t, nil)
+	h.expectErr(postAudio(t, h, string(transcribeEndpoint), ct, raw), CodeUpstreamDown)
+	if n := h.gw.Counters(h.key.ID).TodayAudioSeconds; n != 0 {
+		t.Fatal("model-less request charged")
+	}
+}

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -15,22 +15,24 @@ import (
 type Code string
 
 const (
-	CodeInvalidKey         Code = "invalid_key"
-	CodeKeyPaused          Code = "key_paused"
-	CodeKeyRevoked         Code = "key_revoked"
-	CodeModelNotAllowed    Code = "model_not_allowed"
-	CodeBodyTooLarge       Code = "body_too_large"
-	CodeContextTooLong     Code = "context_too_long"
-	CodeRateLimited        Code = "rate_limited"
-	CodeConcurrencyLimited Code = "concurrency_limited"
-	CodeBudgetExhausted    Code = "budget_exhausted"
-	CodeQueueTimeout       Code = "queue_timeout"
-	CodeUpstreamDown       Code = "upstream_down"
-	CodeUpstreamError      Code = "upstream_error"
-	CodeImagesNotSupported Code = "images_not_supported"
-	CodeInvalidRequest     Code = "invalid_request"
-	CodeNotFound           Code = "not_found"
-	CodeClientClosed       Code = "client_closed"
+	CodeInvalidKey            Code = "invalid_key"
+	CodeKeyPaused             Code = "key_paused"
+	CodeKeyRevoked            Code = "key_revoked"
+	CodeModelNotAllowed       Code = "model_not_allowed"
+	CodeBodyTooLarge          Code = "body_too_large"
+	CodeContextTooLong        Code = "context_too_long"
+	CodeRateLimited           Code = "rate_limited"
+	CodeConcurrencyLimited    Code = "concurrency_limited"
+	CodeBudgetExhausted       Code = "budget_exhausted"
+	CodeQueueTimeout          Code = "queue_timeout"
+	CodeUpstreamDown          Code = "upstream_down"
+	CodeUpstreamError         Code = "upstream_error"
+	CodeAudioBudgetExhausted  Code = "audio_budget_exhausted"
+	CodeSpeechBudgetExhausted Code = "speech_budget_exhausted"
+	CodeImagesNotSupported    Code = "images_not_supported"
+	CodeInvalidRequest        Code = "invalid_request"
+	CodeNotFound              Code = "not_found"
+	CodeClientClosed          Code = "client_closed"
 )
 
 type codeRow struct {
@@ -39,21 +41,23 @@ type codeRow struct {
 }
 
 var codeTable = map[Code]codeRow{
-	CodeInvalidKey:         {http.StatusUnauthorized, "authentication_error"},
-	CodeKeyPaused:          {http.StatusForbidden, "permission_error"},
-	CodeKeyRevoked:         {http.StatusForbidden, "permission_error"},
-	CodeModelNotAllowed:    {http.StatusForbidden, "permission_error"},
-	CodeBodyTooLarge:       {http.StatusRequestEntityTooLarge, "invalid_request_error"},
-	CodeContextTooLong:     {http.StatusUnprocessableEntity, "invalid_request_error"},
-	CodeRateLimited:        {http.StatusTooManyRequests, "rate_limit_error"},
-	CodeConcurrencyLimited: {http.StatusTooManyRequests, "rate_limit_error"},
-	CodeBudgetExhausted:    {http.StatusTooManyRequests, "rate_limit_error"},
-	CodeQueueTimeout:       {http.StatusServiceUnavailable, "upstream_error"},
-	CodeUpstreamDown:       {http.StatusServiceUnavailable, "upstream_error"},
-	CodeUpstreamError:      {http.StatusBadGateway, "upstream_error"},
-	CodeImagesNotSupported: {http.StatusBadRequest, "invalid_request_error"},
-	CodeInvalidRequest:     {http.StatusBadRequest, "invalid_request_error"},
-	CodeNotFound:           {http.StatusNotFound, "invalid_request_error"},
+	CodeInvalidKey:            {http.StatusUnauthorized, "authentication_error"},
+	CodeKeyPaused:             {http.StatusForbidden, "permission_error"},
+	CodeKeyRevoked:            {http.StatusForbidden, "permission_error"},
+	CodeModelNotAllowed:       {http.StatusForbidden, "permission_error"},
+	CodeBodyTooLarge:          {http.StatusRequestEntityTooLarge, "invalid_request_error"},
+	CodeContextTooLong:        {http.StatusUnprocessableEntity, "invalid_request_error"},
+	CodeRateLimited:           {http.StatusTooManyRequests, "rate_limit_error"},
+	CodeConcurrencyLimited:    {http.StatusTooManyRequests, "rate_limit_error"},
+	CodeBudgetExhausted:       {http.StatusTooManyRequests, "rate_limit_error"},
+	CodeQueueTimeout:          {http.StatusServiceUnavailable, "upstream_error"},
+	CodeUpstreamDown:          {http.StatusServiceUnavailable, "upstream_error"},
+	CodeUpstreamError:         {http.StatusBadGateway, "upstream_error"},
+	CodeAudioBudgetExhausted:  {http.StatusTooManyRequests, "rate_limit_error"},
+	CodeSpeechBudgetExhausted: {http.StatusTooManyRequests, "rate_limit_error"},
+	CodeImagesNotSupported:    {http.StatusBadRequest, "invalid_request_error"},
+	CodeInvalidRequest:        {http.StatusBadRequest, "invalid_request_error"},
+	CodeNotFound:              {http.StatusNotFound, "invalid_request_error"},
 }
 
 // gwError is a gateway-originated failure: a code, a human sentence, and (for 429/503) the number of

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -26,10 +26,13 @@ import (
 // here: it is the engine's slot count, read live (DESIGN §1.5). Deadlines and the body cap are
 // constants (§1.6), each bounding one party's failure.
 type Config struct {
-	ModelsPinned []string      // host-wide model allowlist; empty means all models
-	LogPrompts   bool          // put prompt/completion text into usage events (Protection 3: opt-in)
-	HostName     string        // shown in /me
-	RelayRegion  func() string // shown in /me; nil → ""
+	Transcribe, Speech           upstream.AudioEngine
+	TranscribeModel, SpeechModel string
+	MaxTranscriptionSeconds      float64
+	ModelsPinned                 []string      // host-wide model allowlist; empty means all models
+	LogPrompts                   bool          // put prompt/completion text into usage events (Protection 3: opt-in)
+	HostName                     string        // shown in /me
+	RelayRegion                  func() string // shown in /me; nil → ""
 	// DataDir is where usage.jsonl lives; New reads it once to seed today's per-key counters.
 	// Empty means no history to seed from, and the counters start at zero as they always did.
 	DataDir string
@@ -54,14 +57,15 @@ const (
 // Gateway serves the API on any number of listeners (the tunnel, and loopback in dev mode) and
 // implements usage.Snapshot for the admin status API.
 type Gateway struct {
-	cfg    Config
-	up     upstream.Engine // the gateway's whole view of the engine (DESIGN §3.4)
-	store  keys.Store
-	rec    usage.Recorder
-	logf   func(string, ...any)
-	lim    *limiter
-	queue  slotQueue    // global slots; capacity = up.Info().Slots, read at every decision
-	bodies atomic.Int32 // request bodies held in memory (per-key slots bound it; tests read it)
+	audioHistoryErr error
+	cfg             Config
+	up              upstream.Engine // the gateway's whole view of the engine (DESIGN §3.4)
+	store           keys.Store
+	rec             usage.Recorder
+	logf            func(string, ...any)
+	lim             *limiter
+	queue           slotQueue    // global slots; capacity = up.Info().Slots, read at every decision
+	bodies          atomic.Int32 // request bodies held in memory (per-key slots bound it; tests read it)
 
 	// The deadlines, the keepalive and the body cap, unexported: tests shorten them, hosts get the constants.
 	queueTimeout, readTimeout, writeTimeout, idleTimeout, queuedEvery time.Duration
@@ -84,6 +88,9 @@ var _ interface {
 func New(cfg Config, up upstream.Engine, store keys.Store, rec usage.Recorder, logf func(string, ...any)) *Gateway {
 	if logf == nil {
 		logf = func(string, ...any) {}
+	}
+	if cfg.MaxTranscriptionSeconds <= 0 {
+		cfg.MaxTranscriptionSeconds = 300
 	}
 	g := &Gateway{
 		cfg:   cfg,
@@ -116,8 +123,13 @@ func (g *Gateway) seedCounters() {
 	day := g.lim.now().UTC().Truncate(24 * time.Hour)
 	rep, err := usage.AggregateFile(g.cfg.DataDir, usage.Filter{Since: day})
 	if err != nil {
+		g.audioHistoryErr = err
 		g.logf("gateway: today's usage history is unreadable (%v); per-key counters start at zero", err)
 		return
+	}
+	if rep.Malformed > 0 {
+		g.audioHistoryErr = fmt.Errorf("usage history has %d malformed rows", rep.Malformed)
+		g.logf("audio refused: %v", g.audioHistoryErr)
 	}
 	g.lim.seedToday(rep, day)
 }

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -118,7 +118,7 @@ func TestMeShape(t *testing.T) {
 		"":         {"key", "limits", "usage", "host"},
 		"key":      {"id", "name", "status"},
 		"usage":    {"rpm_used", "tpm_used", "today_tokens", "in_flight"},
-		"host":     {"name", "upstream", "models", "vision", "relay", "log_prompts"},
+		"host":     {"name", "upstream", "models", "vision", "audio", "relay", "log_prompts"},
 		"upstream": {"kind", "healthy", "model_context"},
 		"relay":    {"region"},
 	}

--- a/internal/gateway/limits.go
+++ b/internal/gateway/limits.go
@@ -44,23 +44,27 @@ type logEntry struct {
 }
 
 type keyState struct {
-	mu       sync.Mutex
-	log      []logEntry
-	seq      uint64 // the last admission seq handed out
-	inFlight int
-	reserved int       // prompt + max_tokens of requests in flight, counted by TPM and daily until settled
-	day      time.Time // UTC midnight of the day `today` counts
-	today    int
-	lastSeen time.Time
+	audioSeconds, audioReserved float64
+	speechChars, speechReserved int
+	mu                          sync.Mutex
+	log                         []logEntry
+	seq                         uint64 // the last admission seq handed out
+	inFlight                    int
+	reserved                    int       // prompt + max_tokens of requests in flight, counted by TPM and daily until settled
+	day                         time.Time // UTC midnight of the day `today` counts
+	today                       int
+	lastSeen                    time.Time
 }
 
 // admission is what admit hands out and settle takes back: the key, the RPM entry this admission
 // wrote (by seq), and the tokens reserve later put on it. The request record holds it; nothing
 // else ends it.
 type admission struct {
-	key      string
-	seq      uint64
-	reserved int
+	audioSeconds float64
+	speechChars  int
+	key          string
+	seq          uint64
+	reserved     int
 }
 
 // limiter owns all keyState. now is injectable for tests.
@@ -87,6 +91,7 @@ func (l *limiter) seedToday(rep *usage.Report, day time.Time) {
 		st := l.state(s.KeyID)
 		st.mu.Lock()
 		st.day, st.today, st.lastSeen = day, s.PromptTokens+s.CompletionTokens, s.LastSeen
+		st.audioSeconds, st.speechChars = s.Seconds, s.Characters
 		st.mu.Unlock()
 	}
 }
@@ -115,6 +120,7 @@ func (st *keyState) prune(now time.Time) {
 	day := now.UTC().Truncate(24 * time.Hour)
 	if !day.Equal(st.day) {
 		st.day, st.today = day, 0
+		st.audioSeconds, st.speechChars = 0, 0
 	}
 }
 
@@ -296,7 +302,7 @@ func (l *limiter) counters(id string) usage.KeyCounters {
 	defer st.mu.Unlock()
 	st.prune(l.now())
 	reqs, tokens := st.used()
-	return usage.KeyCounters{InFlight: st.inFlight, RPMUsed: reqs, TPMUsed: tokens + st.reserved, TodayTokens: st.today + st.reserved, LastSeen: st.lastSeen}
+	return usage.KeyCounters{TodayAudioSeconds: st.audioSeconds + st.audioReserved, TodaySpeechChars: st.speechChars + st.speechReserved, InFlight: st.inFlight, RPMUsed: reqs, TPMUsed: tokens + st.reserved, TodayTokens: st.today + st.reserved, LastSeen: st.lastSeen}
 }
 
 func (l *limiter) allCounters() map[string]usage.KeyCounters {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -359,7 +359,11 @@ type meResponse struct {
 		} `json:"upstream"`
 		Models []string         `json:"models"`
 		Vision map[string]*bool `json:"vision"`
-		Relay  struct {
+		Audio  struct {
+			Transcriptions *string `json:"transcriptions"`
+			Speech         *string `json:"speech"`
+		} `json:"audio"`
+		Relay struct {
 			Region string `json:"region"`
 		} `json:"relay"`
 		LogPrompts bool `json:"log_prompts"` // the host records prompt text (Protection 3 disclosure; 006 promise 11)
@@ -374,6 +378,13 @@ func (q *request) me() {
 	m.Usage.RPMUsed, m.Usage.TPMUsed, m.Usage.TodayTokens, m.Usage.InFlight = cnt.RPMUsed, cnt.TPMUsed, cnt.TodayTokens, cnt.InFlight
 	info := q.g.up.Info()
 	m.Host.Name = q.g.cfg.HostName
+	m.Host.Audio.Transcriptions = audioModel(q.g.cfg.Transcribe, q.g.cfg.TranscribeModel)
+	m.Host.Audio.Speech = audioModel(q.g.cfg.Speech, q.g.cfg.SpeechModel)
+	for _, model := range []**string{&m.Host.Audio.Transcriptions, &m.Host.Audio.Speech} {
+		if *model != nil && !allowsModel(q.key, q.g.cfg.ModelsPinned, **model) {
+			*model = nil
+		}
+	}
 	m.Host.LogPrompts = q.g.cfg.LogPrompts
 	m.Host.Upstream.Kind, m.Host.Upstream.Healthy, m.Host.Upstream.ModelContext = info.Kind, info.Health.OK, info.ModelContext
 	m.Host.Models = []string{}

--- a/internal/gateway/request.go
+++ b/internal/gateway/request.go
@@ -19,6 +19,8 @@ import (
 type endpoint string
 
 const (
+	transcribeEndpoint endpoint = "/v1/audio/transcriptions"
+	speechEndpoint     endpoint = "/v1/audio/speech"
 	chatEndpoint       endpoint = "/v1/chat/completions"
 	embeddingsEndpoint endpoint = "/v1/embeddings"
 	// modelsEndpoint has no stage list; it is put on the record so the settle table can say what
@@ -31,7 +33,7 @@ const (
 // connect; counting it made the friend's first message read "2 of 20 used this minute" (ticket 014
 // ruling; measured on the real stack, 014 Log).
 func (e endpoint) countsAgainstRPM() bool {
-	return e == chatEndpoint || e == embeddingsEndpoint
+	return e == chatEndpoint || e == embeddingsEndpoint || e == transcribeEndpoint || e == speechEndpoint
 }
 
 // outcome is how a request ended, set by the stage that ended it (DESIGN §1.4). finish reads it
@@ -67,6 +69,7 @@ type normalized struct {
 // rejection, client abort, timeout, and panic all leave through it; no stage releases anything
 // itself (ticket 006 design ruling).
 type request struct {
+	audio *audioRequest
 	g     *Gateway
 	w     http.ResponseWriter
 	r     *http.Request
@@ -116,6 +119,10 @@ func (q *request) serve() {
 		q.me()
 	case r.Method == http.MethodGet && r.URL.Path == "/v1/models":
 		q.models()
+	case r.Method == http.MethodPost && r.URL.Path == string(transcribeEndpoint) && q.g.cfg.Transcribe != nil:
+		q.proxyAudio(transcribeEndpoint, q.g.cfg.Transcribe)
+	case r.Method == http.MethodPost && r.URL.Path == string(speechEndpoint) && q.g.cfg.Speech != nil:
+		q.proxyAudio(speechEndpoint, q.g.cfg.Speech)
 	case r.Method == http.MethodPost && r.URL.Path == string(chatEndpoint):
 		q.proxy(chatEndpoint)
 	case r.Method == http.MethodPost && r.URL.Path == string(embeddingsEndpoint):
@@ -413,6 +420,9 @@ func (q *request) finish() {
 	}
 	if q.adm != nil {
 		counted, charged := q.settleRow()
+		if q.audio != nil {
+			q.settleAudio()
+		}
 		q.g.lim.settle(q.adm, counted, charged)
 	}
 	if q.buffered {
@@ -446,6 +456,9 @@ func (q *request) finish() {
 // A request that never reached an outcome (the pipeline was abandoned by a panic) is a rejection.
 // The event keeps what was observed; only the non-stream Cut charge differs from its token sum.
 func (q *request) settleRow() (counted bool, charged int) {
+	if q.audio != nil {
+		return q.audio.dispatched.Load() || (q.outcome == outcomeQueueLost && q.ev.Code == string(CodeQueueTimeout)), 0
+	}
 	if !q.kind.countsAgainstRPM() {
 		return false, 0
 	}
@@ -470,6 +483,9 @@ func (q *request) settleRow() (counted bool, charged int) {
 func (q *request) fail(e *gwError) {
 	if q.wroteHeader {
 		q.ev.Code = string(e.Code)
+		if q.audio != nil {
+			return
+		}
 		if e.Code != CodeClientClosed && q.r.Context().Err() == nil {
 			q.armWrite()
 			writeStreamError(q.w, e)

--- a/internal/keys/audio_test.go
+++ b/internal/keys/audio_test.go
@@ -1,0 +1,48 @@
+package keys
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLegacyAudioDefaultsAreReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	s, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, secret, err := s.Add(context.Background(), "legacy", Limits{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, FileName)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	_ = json.Unmarshal(b, &doc)
+	for _, entry := range doc["keys"].([]any) {
+		l := entry.(map[string]any)["limits"].(map[string]any)
+		delete(l, "daily_audio_seconds")
+		delete(l, "daily_speech_chars")
+	}
+	before, _ := json.Marshal(doc)
+	if err := os.WriteFile(path, before, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Reload(); err != nil {
+		t.Fatal(err)
+	}
+	k, ok, err := s.Lookup(context.Background(), secret)
+	if err != nil || !ok || k.Limits.DailyAudioSeconds != 3600 || k.Limits.DailySpeechChars != 200000 {
+		t.Fatal("legacy defaults not applied")
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Fatal("read rewrote keys")
+	}
+}

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -18,18 +18,20 @@ const (
 // Limits are per-key. Zero means "use the default" at creation time and "unlimited / upstream's"
 // once stored (MaxContext 0 = upstream context; Models empty = all models).
 type Limits struct {
-	RPM             int      `json:"rpm"`
-	TPM             int      `json:"tpm"`
-	MaxConcurrent   int      `json:"max_concurrent"`
-	MaxOutputTokens int      `json:"max_output_tokens"`
-	MaxContext      int      `json:"max_context"`
-	DailyTokens     int      `json:"daily_tokens"`
-	Models          []string `json:"models,omitempty"`
+	DailyAudioSeconds int      `json:"daily_audio_seconds"`
+	DailySpeechChars  int      `json:"daily_speech_chars"`
+	RPM               int      `json:"rpm"`
+	TPM               int      `json:"tpm"`
+	MaxConcurrent     int      `json:"max_concurrent"`
+	MaxOutputTokens   int      `json:"max_output_tokens"`
+	MaxContext        int      `json:"max_context"`
+	DailyTokens       int      `json:"daily_tokens"`
+	Models            []string `json:"models,omitempty"`
 }
 
 // DefaultLimits are applied at `keys add` when a field is zero.
 func DefaultLimits() Limits {
-	return Limits{RPM: 20, TPM: 20000, MaxConcurrent: 1, MaxOutputTokens: 4096, MaxContext: 0, DailyTokens: 200000}
+	return Limits{DailyAudioSeconds: 3600, DailySpeechChars: 200000, RPM: 20, TPM: 20000, MaxConcurrent: 1, MaxOutputTokens: 4096, MaxContext: 0, DailyTokens: 200000}
 }
 
 // Key is one friend. SecretHash is "sha256:<hex>" of the invite secret; the secret itself is never stored.
@@ -77,3 +79,14 @@ type Admin interface {
 
 // HashSecret returns the canonical "sha256:<hex>" form used in keys.json.
 // Implemented in hash.go (PM-owned) so 002 and 003 share one definition.
+
+// AudioDefaults applies new fields to legacy keys in memory without rewriting the key file.
+func AudioDefaults(l Limits) Limits {
+	if l.DailyAudioSeconds == 0 {
+		l.DailyAudioSeconds = 3600
+	}
+	if l.DailySpeechChars == 0 {
+		l.DailySpeechChars = 200000
+	}
+	return l
+}

--- a/internal/keys/store.go
+++ b/internal/keys/store.go
@@ -107,6 +107,11 @@ func (s *FileStore) reload(force bool) error {
 	if doc.Version != FileVersion {
 		return fmt.Errorf("%s: version %d is not understood by this build (want %d)", s.path, doc.Version, FileVersion)
 	}
+	for _, k := range doc.Keys {
+		if k != nil {
+			k.Limits = AudioDefaults(k.Limits)
+		}
+	}
 	s.keys, s.st, s.loaded = doc.Keys, cur, true
 	return nil
 }
@@ -170,6 +175,7 @@ func (s *FileStore) List(ctx context.Context) ([]*Key, error) {
 // WithDefaults fills the zero fields of l from DefaultLimits. MaxContext 0 (= the upstream's
 // context) and an empty Models list (= every model) are meaningful values and are left alone.
 func WithDefaults(l Limits) Limits {
+	l = AudioDefaults(l)
 	d := DefaultLimits()
 	if l.RPM == 0 {
 		l.RPM = d.RPM

--- a/internal/upstream/audio.go
+++ b/internal/upstream/audio.go
@@ -1,0 +1,77 @@
+package upstream
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// AudioEngine keeps the explicit engine's transport, bearer and address behind the seam.
+type AudioEngine interface {
+	Info() Info
+	Refresh(context.Context) error
+	AudioDo(context.Context, string, string, []byte) (*http.Response, error)
+}
+type audioClient struct {
+	c    *client
+	mu   sync.RWMutex
+	info Info
+}
+
+func OpenAudio(ctx context.Context, rawURL, key string) (AudioEngine, error) {
+	if rawURL == "" {
+		return nil, nil
+	}
+	base, err := normalize(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	a := &audioClient{c: newClient(base, key), info: Info{URL: base.String(), Slots: 1}}
+	_ = a.Refresh(ctx)
+	return a, nil
+}
+func (a *audioClient) Info() Info {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	i := a.info
+	i.Models = append([]string(nil), i.Models...)
+	return i
+}
+
+// Explicit endpoint configuration asserts the route. A successful /v1/models or /health probe
+// asserts reachability only; it does not infer ASR/TTS from model names or generate any content.
+func (a *audioClient) Refresh(ctx context.Context) error {
+	var models modelsResponse
+	err := a.c.getJSON(ctx, "/v1/models", &models)
+	if err != nil {
+		err = a.c.getJSON(ctx, "/health", nil)
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	now := time.Now()
+	a.info.ProbedAt = now
+	if a.info.Health.Since.IsZero() || a.info.Health.OK != (err == nil) {
+		a.info.Health.Since = now
+	}
+	a.info.Health.OK = err == nil
+	a.info.Models = nil
+	if err != nil {
+		a.info.Health.Err = err.Error()
+		return err
+	}
+	a.info.Health.Err = ""
+	for _, m := range models.Data {
+		a.info.Models = append(a.info.Models, m.ID)
+	}
+	return nil
+}
+func (a *audioClient) AudioDo(ctx context.Context, path, contentType string, body []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.c.base.String()+path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return a.c.hc.Do(req)
+}

--- a/internal/upstream/audio_test.go
+++ b/internal/upstream/audio_test.go
@@ -1,0 +1,77 @@
+package upstream
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestExplicitAudioProbeAndTransport(t *testing.T) {
+	var models, health atomic.Bool
+	models.Store(true)
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer audio-key" {
+			t.Error("missing bearer")
+		}
+		switch r.URL.Path {
+		case "/v1/models":
+			if models.Load() {
+				_, _ = io.WriteString(w, `{"data":[{"id":"voice"}]}`)
+			} else {
+				http.NotFound(w, r)
+			}
+		case "/health":
+			if !health.Load() {
+				http.Error(w, "down", 503)
+			} else {
+				_, _ = io.WriteString(w, "healthy")
+			}
+		case "/v1/audio/speech":
+			calls++
+			if r.Header.Get("Content-Type") != "application/custom" {
+				t.Error("content type changed")
+			}
+			b, _ := io.ReadAll(r.Body)
+			if string(b) != "payload" {
+				t.Error("payload changed")
+			}
+			w.Header().Set("Location", "/must-not-follow")
+			w.WriteHeader(307)
+		default:
+			t.Error("followed redirect")
+		}
+	}))
+	defer server.Close()
+	a, err := OpenAudio(context.Background(), server.URL+"/v1", "audio-key")
+	if err != nil || !a.Info().Health.OK || a.Info().Models[0] != "voice" {
+		t.Fatalf("probe %v %+v", err, a.Info())
+	}
+	models.Store(false)
+	health.Store(true)
+	if err := a.Refresh(context.Background()); err != nil || !a.Info().Health.OK {
+		t.Fatal("health fallback failed")
+	}
+	health.Store(false)
+	if err := a.Refresh(context.Background()); err == nil || a.Info().Health.OK {
+		t.Fatal("offline probe was healthy")
+	}
+	r, err := a.AudioDo(context.Background(), "/v1/audio/speech", "application/custom", []byte("payload"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Body.Close()
+	if r.StatusCode != 307 || calls != 1 {
+		t.Fatal("redirect replayed")
+	}
+	if a, err := OpenAudio(context.Background(), "", ""); a != nil || err != nil {
+		t.Fatal("unset route became configured")
+	}
+	if _, err := OpenAudio(context.Background(), "://broken", ""); err == nil || !strings.Contains(err.Error(), "URL") {
+		t.Fatal("invalid URL accepted")
+	}
+}

--- a/internal/usage/aggregate.go
+++ b/internal/usage/aggregate.go
@@ -38,7 +38,7 @@ func (f Filter) match(e *Event) bool {
 // one conversation and put a 3 ms poll in the latency percentiles (ticket 009 promise 6).
 func ModelCall(e *Event) bool {
 	switch e.Endpoint {
-	case "/v1/chat/completions", "/v1/embeddings":
+	case "/v1/chat/completions", "/v1/embeddings", "/v1/audio/transcriptions", "/v1/audio/speech":
 		return true
 	}
 	return false
@@ -46,8 +46,10 @@ func ModelCall(e *Event) bool {
 
 // Stats are the numbers `usage` prints, for one key or for the whole file.
 type Stats struct {
-	KeyID  string         `json:"key_id,omitempty"`
-	Models map[string]int `json:"model_calls_by_model,omitempty"`
+	KeyID      string         `json:"key_id,omitempty"`
+	Models     map[string]int `json:"model_calls_by_model,omitempty"`
+	Seconds    float64        `json:"seconds"`
+	Characters int            `json:"characters"`
 	// Requests is every recorded call; ModelCalls and AppPolls split it into what the friend did
 	// and what their app did. Requests == ModelCalls + AppPolls.
 	Requests         int            `json:"requests"`
@@ -96,6 +98,8 @@ func (s *Stats) add(e *Event) {
 		}
 		s.ErrorsByCode[code]++
 	}
+	s.Seconds += e.Seconds
+	s.Characters += e.Characters
 	s.PromptTokens += e.PromptTokens
 	s.CompletionTokens += e.CompletionTokens
 	// Percentiles are over successful model calls only: a rejected request and a 3 ms /me poll

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -10,6 +10,12 @@ import (
 // Event is one request. No prompt or completion content lives here unless the host opted in,
 // in which case Prompt/Completion are set (Protection 3 in docs/PRINCIPLES.md).
 type Event struct {
+	Kind             string    `json:"kind,omitempty"`
+	Seconds          float64   `json:"seconds,omitempty"`
+	ReservedSeconds  float64   `json:"reserved_seconds,omitempty"`
+	OverrunSeconds   float64   `json:"overrun_seconds,omitempty"`
+	SecondsEstimated bool      `json:"seconds_estimated,omitempty"`
+	Characters       int       `json:"characters,omitempty"`
 	TS               time.Time `json:"ts"`
 	KeyID            string    `json:"key_id"`
 	Endpoint         string    `json:"endpoint"` // "/v1/chat/completions", "/v1/embeddings", "/v1/models", "/me"
@@ -35,11 +41,13 @@ type Recorder interface {
 // Counters are the live per-key numbers the gateway keeps in memory for limits and for /me.
 // Implemented by the gateway (002); exposed to admin status via the Snapshot interface.
 type KeyCounters struct {
-	InFlight    int       `json:"in_flight"`
-	RPMUsed     int       `json:"rpm_used"`
-	TPMUsed     int       `json:"tpm_used"`
-	TodayTokens int       `json:"today_tokens"`
-	LastSeen    time.Time `json:"last_seen"`
+	TodayAudioSeconds float64   `json:"today_audio_seconds"`
+	TodaySpeechChars  int       `json:"today_speech_chars"`
+	InFlight          int       `json:"in_flight"`
+	RPMUsed           int       `json:"rpm_used"`
+	TPMUsed           int       `json:"tpm_used"`
+	TodayTokens       int       `json:"today_tokens"`
+	LastSeen          time.Time `json:"last_seen"`
 }
 
 // Snapshot is what the admin API reads from the running gateway.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -11,6 +11,8 @@ export interface Limits {
   max_output_tokens: number;
   max_context: number;
   daily_tokens: number;
+  daily_audio_seconds?: number;
+  daily_speech_chars?: number;
   models?: string[];
 }
 
@@ -24,7 +26,7 @@ export interface Me {
     models: string[];
     /** Per-model capability; null means the engine did not report it. */
     vision?: Record<string, boolean | null>;
-    audio?: { transcriptions: boolean; speech: boolean };
+    audio?: { transcriptions: string | null; speech: string | null };
     relay: { region: string };
     /** The host runs with --log-prompts. Absent on a gateway older than ticket 006: absent = false. */
     log_prompts?: boolean;
@@ -36,8 +38,8 @@ export function modelVision(me: Me, model: string): boolean | null {
   return me.host.vision?.[model] ?? null;
 }
 
-export function hostAudio(me: Me, kind: 'transcriptions' | 'speech'): boolean {
-  return me.host.audio?.[kind] === true;
+export function hostAudio(me: Me, kind: 'transcriptions' | 'speech'): string | null {
+  return me.host.audio?.[kind] || null;
 }
 
 /** The host's name, trimmed. It can be empty, and "You’re on ." is not a sentence: callers check. */

--- a/web/src/fixtures/me/README.md
+++ b/web/src/fixtures/me/README.md
@@ -4,7 +4,7 @@ Captured 2026-09-09 from actual `infercat serve` binaries built from these refs:
 
 - `0.1.0.json`: v0.1.0, `78fc87f03b7fca2575473daf35150df50a7d9707`.
 - `0.1.1.json`: v0.1.1, `7f1539c6aef14246d86f6fe0a93346dcb7772087`.
-- `current.json`: main `b99fe6d369fae45f8b34bad9390f1fbc29f10b35`.
+- `current.json`: 078 v2 source based on main `e2f9b10` (audio routes with no audio engine configured).
 
 Each binary used a new temporary `--data-dir`, `--dev-listen 127.0.0.1:19082`,
 `--name 'Compatibility host'`, and a loopback test engine. The engine served
@@ -14,9 +14,10 @@ with `keys add --json --no-qr`, then captured authenticated `GET /me`.
 Only the random key id was replaced with `fixture-key`; no other response
 values or fields were edited. No production host or user data was used.
 
-The released shapes are identical. Current adds vision. There is no `host.models_pinned` in the Go wire type: pins filter
-`host.models`. Audio is optional in the client in preparation for 078; its
-landing must refresh current.json and this inventory.
+The released shapes are identical. Current adds vision, nullable audio model ids, and daily audio limits. There is no `host.models_pinned` in the Go wire type: pins filter
+`host.models`. Audio is optional in the client; hostAudio returns the configured model id or
+null. The current fixture captures the unconfigured case. Live ASR/Kokoro proof
+separately verifies configured model ids and requests without a model field.
 
 `make host-compat` renders Connect → Chat with each response. Files are independent
 of host vision, so the + stays present on old hosts but its accept list excludes

--- a/web/src/fixtures/me/current.json
+++ b/web/src/fixtures/me/current.json
@@ -5,6 +5,8 @@
     "status": "active"
   },
   "limits": {
+    "daily_audio_seconds": 3600,
+    "daily_speech_chars": 200000,
     "rpm": 20,
     "tpm": 20000,
     "max_concurrent": 1,
@@ -30,6 +32,10 @@
     ],
     "vision": {
       "compat-model": true
+    },
+    "audio": {
+      "transcriptions": null,
+      "speech": null
     },
     "relay": {
       "region": "New York City"

--- a/web/src/host-compat.test.ts
+++ b/web/src/host-compat.test.ts
@@ -17,7 +17,7 @@ describe('shipped host capabilities', () => {
     for (const m of host.members) {
       if (!(m.name!.getText(source) in old.host)) expect((m as ts.PropertySignature).questionToken).toBeDefined();
     }
-    expect(Object.keys(current.host).sort()).toEqual(['log_prompts', 'models', 'name', 'relay', 'upstream', 'vision']);
+    expect(Object.keys(current.host).sort()).toEqual(['audio', 'log_prompts', 'models', 'name', 'relay', 'upstream', 'vision']);
   });
   it('requires current fixture coverage for Go wire field names', () => {
     const proxy = readFileSync(new URL('../../internal/gateway/proxy.go', import.meta.url), 'utf8');
@@ -34,15 +34,15 @@ describe('shipped host capabilities', () => {
   });
   it('defaults absent capabilities honestly, retaining explicit false and unknown', () => {
     expect(modelVision(old as Me, 'compat-model')).toBeNull();
-    expect(hostAudio(old as Me, 'transcriptions')).toBe(false);
-    expect(hostAudio(old as Me, 'speech')).toBe(false);
+    expect(hostAudio(old as Me, 'transcriptions')).toBeNull();
+    expect(hostAudio(old as Me, 'speech')).toBeNull();
     expect(modelVision(current as Me, 'compat-model')).toBe(true);
     expect(modelVision(current as Me, 'missing')).toBeNull();
-    const me = { ...current, host: { ...current.host, vision: { text: false, unknown: null }, audio: { transcriptions: true, speech: false } } } as Me;
+    const me = { ...current, host: { ...current.host, vision: { text: false, unknown: null }, audio: { transcriptions: 'asr-model', speech: null } } } as Me;
     expect(modelVision(me, 'text')).toBe(false);
     expect(modelVision(me, 'unknown')).toBeNull();
-    expect(hostAudio(me, 'transcriptions')).toBe(true);
-    expect(hostAudio(me, 'speech')).toBe(false);
+    expect(hostAudio(me, 'transcriptions')).toBe('asr-model');
+    expect(hostAudio(me, 'speech')).toBeNull();
     expect(logsPrompts({ ...me, host: { ...me.host, log_prompts: undefined } })).toBe(false);
   });
   it('keeps capability property reads inside the API accessor boundary', () => {


### PR DESCRIPTION
Hosts can explicitly configure OpenAI-compatible transcription and speech engines, with separate daily seconds/character budgets. Audio routes share the gateway's authentication, model allowlists, concurrency, queueing, deadlines, and settlement. Default/json transcription asks the engine for verbose_json internally and returns only {"text"}, so ordinary SDK and phone uploads settle measured duration without requiring client opt-in. Text/SRT/VTT keep reservation charging, documented in LIMITS.md.

Missing or unknown request model ids resolve to the host's optional --upstream-transcribe-model / --upstream-speech-model, otherwise the first probed engine id. The selected id must pass both invite and host allowlists. /me.host.audio exposes nullable model ids; the web accessor and current-host compatibility fixture match, while released fixtures remain intact. Malformed usage history emits a startup refusal message and refuses audio.

Core proof: local Speaches (faster-whisper-tiny.en) and Kokoro, isolated --data-dir. Requests omitted both model and transcription response_format. A 10 s MP3 returned only text and recorded seconds=10, reserved_seconds=300; a 15 s key's second 10 s WAV, a 5 s key's first WAV, and an unknown-duration upload under a 200 s budget were all refused before dispatch. Speech returned 76,460 bytes of valid 24 kHz mono PCM, charging 20 Unicode characters. Real proof: 6 requests passed / 0 failed, 3 refusals never dispatched. Unit proof: thirteen short default-format clips charge 32.5 s, not 3,900 s.

Validation: make check OK; Go 339 passed / 0 failed / 2 existing live skips; console 14/0/0; client 27/0/1 existing live skip; compatibility unit 4/0/0, browser 5/0/0; installer 18/0/0. Full web suite 325/0/0. Real-engine proof and ffmpeg decode passed. A fresh capture from the final rebased binary exactly matched current.json. Edge coverage includes textual formats, health-only engines needing a configured model, fallback and allowlists, truthful overruns, concurrent reservations, disconnected settlement, UTC rollover and replay. Only WAV (PCM/float) and FLAC duration headers are measured; unknown formats reserve the policy ceiling. This cannot bound decoded duration, and full engine overruns remain charged truthfully.

No production host, founder workstation, or deployment was touched. No audio/text is logged, including with --log-prompts. The status audio map and the web compatibility updates are required additive wiring; no voice UI is included. 080 should read model ids through hostAudio(me, kind), send no model field, and reuse the shared sendBlocked gate.

Freeze v2: L2, size 4. Base e2f9b10f2329fa0f32c79b201c94991992ade86a (082 landed); tip 621da7b74e0edaf27f435df9a1bfc0225afdb630. One commit. Binary patch SHA-256 b186b7e36ead2f3132547a43ad87ff27e52d0e11f97a6ad89f2bcec59d1312f9.
Accounting against base: source +791/-114; tests/fixtures +768/-7; docs +85/-5; total +1644/-126, 30 files. No numeric LOC ceiling was specified. Concepts: 9 flags/settings (including the 2 newly ruled model flags), 2 routes, 2 error codes = 13; no new state file or CLI verb.
