### PR TITLE
082: guard additive host capabilities and check shipped shapes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ test:
 vet:
 	go vet ./...
 
-check: console-check vet test client-check web-lint
+check: console-check vet test client-check web-lint host-compat
 	sh hack/install_test.sh
 	@if command -v shellcheck >/dev/null 2>&1; then shellcheck -s sh hack/install.sh; else echo "shellcheck: skipped (not installed)"; fi
 	@echo "CHECK OK"
@@ -103,3 +103,10 @@ console-check:
 .PHONY: console-build
 console-build:
 	cd console && pnpm install --frozen-lockfile && pnpm build
+
+# Shipped /me shapes must render Connect → Chat; install the pinned browser on clean machines.
+.PHONY: host-compat
+host-compat: web-lint
+	cd web && pnpm typecheck && pnpm exec vitest run src/host-compat.test.ts
+	cd web && pnpm exec playwright install --with-deps chromium
+	cd web && pnpm exec node dev/host-compat.mjs

--- a/web/dev/host-compat.mjs
+++ b/web/dev/host-compat.mjs
@@ -1,0 +1,56 @@
+// Real Connect → Chat rendering against captured /me responses, no relay or model required.
+import { readFileSync } from 'node:fs';
+import assert from 'node:assert/strict';
+import { createServer } from 'vite';
+import { chromium } from 'playwright';
+import { assertLive } from './live-assert.mjs';
+const invite = `ic1.tcCOMPATproofaddressCOMPATproofaddress.${'D'.repeat(43)}`;
+const server = await createServer({ server: { port: 0, strictPort: false } });
+await server.listen();
+const base = server.resolvedUrls.local[0];
+const browser = await chromium.launch({ headless: true });
+let passed = 0;
+try {
+  for (const version of ['0.1.0', '0.1.1', 'current']) {
+    const fixture = JSON.parse(readFileSync(new URL(`../src/fixtures/me/${version}.json`, import.meta.url), 'utf8'));
+    const context = await browser.newContext({ locale: 'en-US' });
+    try {
+      const page = await context.newPage();
+      let reads = 0;
+      const respond = async (route) => {
+        const path = new URL(route.request().url()).pathname;
+        if (path === '/me') reads++;
+        const body = path === '/me' ? fixture : path === '/v1/models' ? { data: fixture.host.models.map((id) => ({ id })) } : { status: 'ok' };
+        await route.fulfill({ json: body, headers: { 'access-control-allow-origin': '*' } });
+      };
+      await context.route('http://127.0.0.1:49090/**', respond);
+      const observed = await assertLive(page, `${base}?direct#${invite}`);
+      assert.ok(reads > 0, 'Connect verified the fixture through /me');
+      assert.equal(observed.images, fixture.host.vision?.[fixture.host.models[0]] === true);
+      assert.equal(observed.microphone, false);
+      assert.equal(observed.listen, false);
+      // The + remains available for files on old hosts; image MIME types must be absent.
+      assert.equal(await page.locator('.composer .attach').count(), 1);
+      console.log(`COMPAT ${version} PASS ${JSON.stringify(observed)}`);
+      if (process.env.COMPAT_SHOTS) await page.screenshot({ path: `${process.env.COMPAT_SHOTS}/compat-${version}.png` });
+      passed++;
+      await page.close();
+      if (version === '0.1.0') {
+        for (const failure of ['console', 'pageerror']) {
+          const probeContext = await browser.newContext({ locale: 'en-US' });
+          await probeContext.route('http://127.0.0.1:49090/**', respond);
+          const probe = await probeContext.newPage();
+          await probe.addInitScript((kind) => {
+            if (kind === 'console') console.error('compatibility gate injected error');
+            else throw new Error('compatibility gate injected exception');
+          }, failure);
+          await assert.rejects(assertLive(probe, `${base}?direct#${invite}`), /browser errors/);
+          await probeContext.close();
+          console.log(`LIVE rejects ${failure} PASS`);
+          passed++;
+        }
+      }
+    } finally { await context.close(); }
+  }
+  console.log(`Host compatibility: ${passed} passed / 0 failed / 0 skipped`);
+} finally { await browser.close(); await server.close(); }

--- a/web/dev/live-assert.mjs
+++ b/web/dev/live-assert.mjs
@@ -1,0 +1,43 @@
+// Post-deploy gate: node dev/live-assert.mjs [https://infercat.ai/try]
+// INVITE optionally supplies an invite without printing it. No message is sent.
+import assert from 'node:assert/strict';
+import { pathToFileURL } from 'node:url';
+import { chromium } from 'playwright';
+
+export async function assertLive(page, url) {
+  const errors = [];
+  const onError = (e) => errors.push(String(e));
+  const onConsole = (m) => { if (m.type() === 'error') errors.push(m.text()); };
+  page.on('pageerror', onError);
+  page.on('console', onConsole);
+  try {
+    await page.goto(url);
+    // This status is a paragraph below the host heading, not an h1.
+    await page.locator('.empty').getByText(/is listening/).waitFor({ timeout: 120_000 });
+    const composer = page.locator('.composer textarea');
+    await composer.waitFor();
+    assert.equal(await composer.isEnabled(), true, 'composer must be enabled');
+    const accept = await page.locator('.composer input[type=file]').getAttribute('accept').catch(() => '');
+    const observed = {
+      composer: true,
+      images: /image\//.test(accept ?? ''),
+      microphone: await page.locator('.composer .mic').count() > 0,
+      listen: await page.getByRole('button', { name: 'Listen', exact: true }).count() > 0,
+    };
+    assert.deepEqual(errors, [], 'browser errors');
+    return observed;
+  } finally {
+    page.off('pageerror', onError);
+    page.off('console', onConsole);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const url = new URL(process.argv[2] ?? 'https://infercat.ai/try');
+  if (process.env.INVITE) { url.pathname = '/'; url.hash = process.env.INVITE; }
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({ locale: 'en-US' });
+    console.log('LIVE PASS', JSON.stringify(await assertLive(page, url.href)));
+  } finally { await browser.close(); }
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -23,11 +23,21 @@ export interface Me {
     upstream: { kind: string; healthy: boolean; model_context: number };
     models: string[];
     /** Per-model capability; null means the engine did not report it. */
-    vision: Record<string, boolean | null>;
+    vision?: Record<string, boolean | null>;
+    audio?: { transcriptions: boolean; speech: boolean };
     relay: { region: string };
     /** The host runs with --log-prompts. Absent on a gateway older than ticket 006: absent = false. */
     log_prompts?: boolean;
   };
+}
+
+/** Capabilities are additive: a host that predates a field makes no promise about it. */
+export function modelVision(me: Me, model: string): boolean | null {
+  return me.host.vision?.[model] ?? null;
+}
+
+export function hostAudio(me: Me, kind: 'transcriptions' | 'speech'): boolean {
+  return me.host.audio?.[kind] === true;
 }
 
 /** The host's name, trimmed. It can be empty, and "You’re on ." is not a sentence: callers check. */

--- a/web/src/fixtures/me/0.1.0.json
+++ b/web/src/fixtures/me/0.1.0.json
@@ -1,0 +1,36 @@
+{
+  "key": {
+    "id": "fixture-key",
+    "name": "compat-fixture",
+    "status": "active"
+  },
+  "limits": {
+    "rpm": 20,
+    "tpm": 20000,
+    "max_concurrent": 1,
+    "max_output_tokens": 4096,
+    "max_context": 0,
+    "daily_tokens": 200000
+  },
+  "usage": {
+    "rpm_used": 0,
+    "tpm_used": 0,
+    "today_tokens": 0,
+    "in_flight": 0
+  },
+  "host": {
+    "name": "Compatibility host",
+    "upstream": {
+      "kind": "llama.cpp",
+      "healthy": true,
+      "model_context": 8192
+    },
+    "models": [
+      "compat-model"
+    ],
+    "relay": {
+      "region": "New York City"
+    },
+    "log_prompts": false
+  }
+}

--- a/web/src/fixtures/me/0.1.1.json
+++ b/web/src/fixtures/me/0.1.1.json
@@ -1,0 +1,36 @@
+{
+  "key": {
+    "id": "fixture-key",
+    "name": "compat-fixture",
+    "status": "active"
+  },
+  "limits": {
+    "rpm": 20,
+    "tpm": 20000,
+    "max_concurrent": 1,
+    "max_output_tokens": 4096,
+    "max_context": 0,
+    "daily_tokens": 200000
+  },
+  "usage": {
+    "rpm_used": 0,
+    "tpm_used": 0,
+    "today_tokens": 0,
+    "in_flight": 0
+  },
+  "host": {
+    "name": "Compatibility host",
+    "upstream": {
+      "kind": "llama.cpp",
+      "healthy": true,
+      "model_context": 8192
+    },
+    "models": [
+      "compat-model"
+    ],
+    "relay": {
+      "region": "New York City"
+    },
+    "log_prompts": false
+  }
+}

--- a/web/src/fixtures/me/README.md
+++ b/web/src/fixtures/me/README.md
@@ -1,0 +1,30 @@
+# Captured host responses
+
+Captured 2026-09-09 from actual `infercat serve` binaries built from these refs:
+
+- `0.1.0.json`: v0.1.0, `78fc87f03b7fca2575473daf35150df50a7d9707`.
+- `0.1.1.json`: v0.1.1, `7f1539c6aef14246d86f6fe0a93346dcb7772087`.
+- `current.json`: main `b99fe6d369fae45f8b34bad9390f1fbc29f10b35`.
+
+Each binary used a new temporary `--data-dir`, `--dev-listen 127.0.0.1:19082`,
+`--name 'Compatibility host'`, and a loopback test engine. The engine served
+`/v1/models` with `compat-model`, `/props` with 8192 context, one slot and
+`modalities.vision: true`, and healthy `/health`. We minted `compat-fixture`
+with `keys add --json --no-qr`, then captured authenticated `GET /me`.
+Only the random key id was replaced with `fixture-key`; no other response
+values or fields were edited. No production host or user data was used.
+
+The released shapes are identical. Current adds vision. There is no `host.models_pinned` in the Go wire type: pins filter
+`host.models`. Audio is optional in the client in preparation for 078; its
+landing must refresh current.json and this inventory.
+
+`make host-compat` renders Connect → Chat with each response. Files are independent
+of host vision, so the + stays present on old hosts but its accept list excludes
+images. The capability accessor tests enumerate optional fields and prohibit
+capability property reads outside api.ts. Refresh fixtures and expectations when
+extending /me; retain every shipped-version fixture.
+
+Post-deploy: `cd web && pnpm exec node dev/live-assert.mjs [URL]` (default /try).
+Set INVITE to use a specific invite without printing it. The script observes the
+empty chat's controls, so `listen: false` means no Listen button was rendered;
+it does not infer speech capability from an empty history. It never sends a chat.

--- a/web/src/fixtures/me/current.json
+++ b/web/src/fixtures/me/current.json
@@ -1,0 +1,39 @@
+{
+  "key": {
+    "id": "fixture-key",
+    "name": "compat-fixture",
+    "status": "active"
+  },
+  "limits": {
+    "rpm": 20,
+    "tpm": 20000,
+    "max_concurrent": 1,
+    "max_output_tokens": 4096,
+    "max_context": 0,
+    "daily_tokens": 200000
+  },
+  "usage": {
+    "rpm_used": 0,
+    "tpm_used": 0,
+    "today_tokens": 0,
+    "in_flight": 0
+  },
+  "host": {
+    "name": "Compatibility host",
+    "upstream": {
+      "kind": "llama.cpp",
+      "healthy": true,
+      "model_context": 8192
+    },
+    "models": [
+      "compat-model"
+    ],
+    "vision": {
+      "compat-model": true
+    },
+    "relay": {
+      "region": "New York City"
+    },
+    "log_prompts": false
+  }
+}

--- a/web/src/host-compat.test.ts
+++ b/web/src/host-compat.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import ts from 'typescript';
+import { hostAudio, logsPrompts, modelVision, type Me } from './api';
+import old from './fixtures/me/0.1.0.json';
+import current from './fixtures/me/current.json';
+
+const source = ts.createSourceFile('api.ts', readFileSync(new URL('./api.ts', import.meta.url), 'utf8'), ts.ScriptTarget.Latest, true);
+const me = source.statements.find((s): s is ts.InterfaceDeclaration => ts.isInterfaceDeclaration(s) && s.name.text === 'Me')!;
+const host = (me.members.find((m) => m.name?.getText(source) === 'host') as ts.PropertySignature).type as ts.TypeLiteralNode;
+// Explicit extension inventory (082's size-1 alternative to a generated Go schema).
+const optional = ['audio', 'log_prompts', 'vision'];
+
+describe('shipped host capabilities', () => {
+  it('keeps additive fields optional and requires an explicit inventory update', () => {
+    expect(host.members.filter((m) => (m as ts.PropertySignature).questionToken).map((m) => m.name?.getText(source)).sort()).toEqual(optional);
+    for (const m of host.members) {
+      if (!(m.name!.getText(source) in old.host)) expect((m as ts.PropertySignature).questionToken).toBeDefined();
+    }
+    expect(Object.keys(current.host).sort()).toEqual(['log_prompts', 'models', 'name', 'relay', 'upstream', 'vision']);
+  });
+  it('requires current fixture coverage for Go wire field names', () => {
+    const proxy = readFileSync(new URL('../../internal/gateway/proxy.go', import.meta.url), 'utf8');
+    const wire = proxy.split('type meResponse struct {')[1]!.split('\nfunc ')[0]!;
+    const names = [...wire.matchAll(/json:"([^",]+)[^"]*"/g)].map((m) => m[1]);
+    const fields = new Set<string>();
+    function collect(value: unknown): void {
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        for (const [key, child] of Object.entries(value)) { fields.add(key); collect(child); }
+      }
+    }
+    collect(current);
+    for (const name of names) expect(fields.has(name!), `capture current /me field ${name}`).toBe(true);
+  });
+  it('defaults absent capabilities honestly, retaining explicit false and unknown', () => {
+    expect(modelVision(old as Me, 'compat-model')).toBeNull();
+    expect(hostAudio(old as Me, 'transcriptions')).toBe(false);
+    expect(hostAudio(old as Me, 'speech')).toBe(false);
+    expect(modelVision(current as Me, 'compat-model')).toBe(true);
+    expect(modelVision(current as Me, 'missing')).toBeNull();
+    const me = { ...current, host: { ...current.host, vision: { text: false, unknown: null }, audio: { transcriptions: true, speech: false } } } as Me;
+    expect(modelVision(me, 'text')).toBe(false);
+    expect(modelVision(me, 'unknown')).toBeNull();
+    expect(hostAudio(me, 'transcriptions')).toBe(true);
+    expect(hostAudio(me, 'speech')).toBe(false);
+    expect(logsPrompts({ ...me, host: { ...me.host, log_prompts: undefined } })).toBe(false);
+  });
+  it('keeps capability property reads inside the API accessor boundary', () => {
+    const configPath = new URL('../tsconfig.json', import.meta.url).pathname;
+    const config = ts.readConfigFile(configPath, ts.sys.readFile);
+    const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, new URL('../', import.meta.url).pathname);
+    const program = ts.createProgram(parsed.fileNames, parsed.options);
+    const checker = program.getTypeChecker();
+    const isHost = (n: ts.Node): boolean => ['name', 'upstream', 'models', 'relay'].every((key) => checker.getTypeAtLocation(n).getProperty(key));
+    for (const tree of program.getSourceFiles()) {
+      if (!tree.fileName.includes('/web/src/') || tree.fileName.endsWith('/api.ts') || tree.fileName.endsWith('.test.ts')) continue;
+      function visit(n: ts.Node): void {
+        if (ts.isPropertyAccessExpression(n) && isHost(n.expression)) expect(optional.includes(n.name.text), `${tree.fileName}: use a capability accessor`).toBe(false);
+        if (ts.isElementAccessExpression(n) && isHost(n.expression)) expect(ts.isStringLiteral(n.argumentExpression) && !optional.includes(n.argumentExpression.text), `${tree.fileName}: use a capability accessor`).toBe(true);
+        if (ts.isObjectBindingPattern(n) && isHost(n)) for (const item of n.elements) expect(optional.includes((item.propertyName ?? item.name).getText(tree)), `${tree.fileName}: use a capability accessor`).toBe(false);
+        ts.forEachChild(n, visit);
+      }
+      visit(tree);
+    }
+  });
+});

--- a/web/src/ui/Chat.tsx
+++ b/web/src/ui/Chat.tsx
@@ -14,6 +14,7 @@ import {
   logsPrompts,
   ME_TIMEOUT_MS,
   modelLabel,
+  modelVision,
   timeoutSignal,
   type FriendlyError,
   type Me,
@@ -142,7 +143,7 @@ export default function Chat({ state, live, dispatch, onRedial, reconnecting = f
   const conv = convs.find((c) => c.id === currentId) ?? (convs[0] as Conversation);
   const models = me.host.models.length > 0 ? me.host.models : listed;
   const model = modelFor(settings.model, models) ?? models[0] ?? '';
-  const vision = live.meOk && me.host.vision?.[model] === true;
+  const vision = live.meOk && modelVision(me, model) === true;
   const imageRefs = JSON.stringify(conv.messages.filter((m) => m.images?.length).map(({ id, images }) => ({ id, images })));
   useEffect(() => {
     let active = true;
@@ -1065,7 +1066,7 @@ function SettingsSheet({
           {tr('app_settings_limits', { rpm: me.limits.rpm, daily: compact(me.limits.daily_tokens), concurrent: me.limits.max_concurrent, output: compact(me.limits.max_output_tokens) })}{' '}
           {tr('app_settings_engine', { engine: me.host.upstream.kind })}
           {me.host.upstream.model_context > 0 ? tr('app_settings_context', { context: compact(me.host.upstream.model_context) }) : ''}
-          {live.meOk && me.host.vision?.[chosen] === true ? tr('app_settings_vision') : ''}
+          {live.meOk && modelVision(me, chosen) === true ? tr('app_settings_vision') : ''}
           {live.meOk && !me.host.upstream.healthy ? tr('app_not_answering_right_now') : ''}.{' '}
           <Text name="app_settings_model_id" values={{ model: <code>{chosen || tr('app_none')}</code> }} />
           {live.ephemeral


### PR DESCRIPTION
The deployed app must render against hosts that predate image support. Vision and audio are optional, with capability reads centralized in `modelVision`, `hostAudio`, and the existing `logsPrompts`. Unknown vision stays null; absent audio stays false.

`make check` now renders Connect → Chat against responses captured from actual v0.1.0, v0.1.1, and current host binaries in isolated temporary data directories. All three render; old hosts retain file attachment controls without image MIME types. A typed source check rejects capability reads outside the accessors, an explicit optional-field inventory guards additions, and current fixture coverage checks Go wire field names. This is deliberately not a complete generated JSON schema. `live-assert.mjs` checks the listening status and enabled composer after deploys, reports rendered controls, and fails on console errors or uncaught exceptions. Independent injected failures verify both paths.

Validation: `make check` OK; Go 302 passed / 0 failed / 2 existing opt-in skips; console 14/0/0; client 27/0/1 existing live skip; compatibility unit checks 4/0/0 and browser checks 5/0/0; installer 18/0/0. Full web suite: 325/0/0. Restoring the original unguarded read and omitting vision from the current fixture each failed the intended guard, then were restored. Screenshots inspected locally.

No host code or production environment was changed. `host.models_pinned` does not exist on the wire: host pinning filters `host.models`. When 078 lands, its new audio wire fields require a current fixture refresh. The live gate reports observed empty-chat controls, not inferred speech support from an absent Listen button.

Freeze: L2, size 1. Base `b99fe6d369fae45f8b34bad9390f1fbc29f10b35`; tip `936c9bd1b1106cae8ec6c66e2231347e2c13592a`; binary patch SHA-256 `d64afde2b81c20737124db1112af7f46bc5aa5600391a915aa262faece21759d`.
Accounting: source +65/-4 (includes Makefile and live gate), tests/fixtures +233/-0, docs +30/-0; total +328/-4 across 10 files. No numeric LOC ceiling was specified. Public CLI/config/error/state concepts added: 0. Development entry points: `make host-compat`, `node web/dev/live-assert.mjs [URL]`.
