### PR TITLE
099: show microphone feedback from recording startup

### DIFF
--- a/web/dev/voice-check.mjs
+++ b/web/dev/voice-check.mjs
@@ -17,6 +17,7 @@ async function connected(width, lang, extra = '&transcriptions&speech') {
     window.localStorage.setItem('bn.language', JSON.stringify(language));
     window.__level = .13; window.__micError = ''; window.__tracksStopped = 0;
     Object.defineProperty(window.navigator, 'mediaDevices', { configurable: true, value: { getUserMedia: async () => {
+      if (window.__holdMic) await new Promise((resolve) => { window.__permitMic = resolve; });
       if (window.__micError) throw new window.DOMException('microphone unavailable', window.__micError);
       return { getTracks: () => [{ stop: () => window.__tracksStopped++ }] };
     } } });
@@ -62,6 +63,15 @@ try {
     try {
       check(await mic.count() === 1, 'capability exposes microphone');
       await shot(page, `idle-${tag}`);
+      await page.evaluate(() => { window.__holdMic = true; }); await mic.click();
+      check((await page.locator('.composer .spoken').innerText()).includes(lang === 'zh' ? '正在等待麦克风' : 'Waiting for the microphone'), 'permission pending is honestly labelled');
+      check(await page.locator('.composer .waveform').count() === 0, 'no recording waveform before permission');
+      await shot(page, `waiting-${tag}`);
+      await page.locator('.composer .spoken button').click();
+      await page.evaluate(() => { window.__holdMic = false; window.__permitMic(); });
+      await page.waitForTimeout(30);
+      check(await page.locator('.composer .spoken').count() === 0, 'late permission stays cancelled');
+
       await page.getByRole('button', { name: lang === 'zh' ? '设置' : 'Settings', exact: true }).click();
       check((await page.locator('.sheet').innerText()).includes('whisper-large-v3') && (await page.locator('.sheet').innerText()).includes('kokoro'), 'Settings names both audio models');
       await page.locator('.sheet .small-print').first().scrollIntoViewIfNeeded(); await shot(page, `settings-${tag}`);
@@ -135,7 +145,9 @@ try {
     const no = await connected(width, lang, '');
     check(await no.page.locator('.mic').count() === 0, 'absent capability hides microphone'); await shot(no.page, `no-voice-${tag}`); await no.context.close();
     const bad = await connected(width, lang, '&transcriptions&speech&audioFailure=429');
-    await bad.page.locator('.mic').click(); await bad.page.waitForTimeout(100); await bad.page.locator('.mic').click();
+    await bad.page.locator('.mic').click();
+    await bad.page.waitForFunction(() => document.querySelector('.mic')?.getAttribute('aria-pressed') === 'true');
+    await bad.page.locator('.mic').click();
     await bad.page.locator('.spoken.bad').waitFor(); await shot(bad.page, `transcription-refused-${tag}`);
     check(await bad.page.locator('.banner .banner-actions button').count() === 1, 'audio cooldown never offers chat regeneration');
     await bad.page.locator('.composer textarea').fill('A reply to listen to.'); await bad.page.locator('.composer .primary').click();

--- a/web/dev/voice-start-check.mjs
+++ b/web/dev/voice-start-check.mjs
@@ -1,0 +1,54 @@
+// Native media APIs with browser fake devices; timestamps are ms from the click.
+import assert from 'node:assert/strict';
+import { Buffer } from 'node:buffer';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { chromium, firefox, webkit } from 'playwright';
+const base = process.env.VOICE_CHECK_URL ?? 'http://127.0.0.1:49199';
+// Chromium's default fake source begins with silence; use a tone from sample zero.
+const dir = mkdtempSync(join(tmpdir(), 'voice-start-'));
+const tone = Buffer.alloc(44 + 32000);
+tone.write('RIFF'); tone.writeUInt32LE(tone.length - 8, 4); tone.write('WAVEfmt ', 8);
+tone.writeUInt32LE(16, 16); tone.writeUInt16LE(1, 20); tone.writeUInt16LE(1, 22);
+tone.writeUInt32LE(16000, 24); tone.writeUInt32LE(32000, 28); tone.writeUInt16LE(2, 32);
+tone.writeUInt16LE(16, 34); tone.write('data', 36); tone.writeUInt32LE(32000, 40);
+for (let i = 0; i < 16000; i++) tone.writeInt16LE(Math.round(16000 * Math.cos(i * 2 * Math.PI * 440 / 16000)), 44 + 2 * i);
+const file = join(dir, 'tone.wav'); writeFileSync(file, tone);
+try {
+for (const [name, type] of Object.entries({ chromium, firefox, webkit })) {
+  const browser = await type.launch({headless:true, ...(name === 'chromium' ? {args:['--use-fake-device-for-media-stream','--use-fake-ui-for-media-stream', `--use-file-for-fake-audio-capture=${file}`]} : name === 'firefox' ? {firefoxUserPrefs:{'media.navigator.streams.fake':true,'media.navigator.permission.disabled':true}} : {})});
+  try {
+    const page = await browser.newPage();
+    await page.route('**/voice-start-test', r => r.fulfill({contentType:'text/html',body:'<button id="start">Record</button><svg><path id="wave" /></svg>'}));
+    await page.goto(base+'/voice-start-test');
+    await page.evaluate(async ({synthetic, module}) => {
+      const {VoiceRecorder}=await import(module);
+      window.times={}; const mark=k=>{window.times[k]??=Math.round((performance.now()-window.tap)*10)/10;};
+      const SourceContext = window.AudioContext;
+      const gum = synthetic ? async () => {
+        const context = new SourceContext(); await context.resume();
+        const oscillator = context.createOscillator();
+        const output = context.createMediaStreamDestination(); oscillator.connect(output); oscillator.start();
+        window.closeSource = () => { oscillator.stop(); void context.close(); };
+        return output.stream;
+      } : window.navigator.mediaDevices.getUserMedia.bind(window.navigator.mediaDevices);
+      Object.defineProperty(window.navigator, 'mediaDevices', {configurable:true, value:{getUserMedia:async o=>{const s=await gum(o); mark('stream'); window.stream=s; return s;}}});
+      const NativeContext=window.AudioContext;
+      window.AudioContext=class extends NativeContext { constructor(...a){super(...a); this.addEventListener('statechange',()=>{if(this.state==='running')mark('context');}); const create=this.createAnalyser.bind(this); this.createAnalyser=()=>{const n=create(); const read=n.getFloatTimeDomainData.bind(n); n.getFloatTimeDomainData=a=>{read(a); mark('analyser'); if(a.some(x=>x!==0))mark('signal');}; return n;};}};
+      const NativeRecorder=window.MediaRecorder;
+      window.MediaRecorder=class extends NativeRecorder {start(...a){mark('captureStart');this.addEventListener('dataavailable',()=>mark('data'));super.start(...a);}};
+      window.recorder=new VoiceRecorder(async()=>'', s=>{if(s.kind==='recording'){mark('recordingUI');window.requestAnimationFrame(()=>mark('drawnFrame'));document.querySelector('#wave').setAttribute('d',s.waveform.map((x,i)=>`M${i} 0v${x}`).join(' '));if(s.waveform.some(x=>x>0))window.requestAnimationFrame(()=>mark('drawnSignal'));}});
+      document.querySelector('#start').onclick=()=>{window.times={};window.tap=performance.now();void window.recorder.start();};
+    }, {synthetic: name === 'webkit', module: process.env.VOICE_START_MODULE ?? '/src/voice.ts'});
+    for(let i=0;i<2;i++){
+      await page.click('#start'); await page.waitForTimeout(2000);
+      console.log(name,browser.version(),name === 'webkit' ? 'oscillator-stream' : 'native-fake-device',i===0?'first':'repeat',JSON.stringify(await page.evaluate(()=>({times:window.times,state:window.recorder.state.kind}))));
+      assert.equal(await page.evaluate(()=>window.recorder.state.kind), 'recording');
+      assert.equal(await page.evaluate(()=>window.times.captureStart <= window.times.recordingUI), true);
+      await page.evaluate(()=>{window.recorder.cancel();window.closeSource?.();});
+      if(await page.evaluate(()=>window.stream?.getTracks().some(t=>t.readyState!=='ended')))throw Error('microphone retained');
+    }
+  }finally{await browser.close();}
+}
+} finally { rmSync(dir, { recursive: true, force: true }); }

--- a/web/dev/voice-start-measurements.md
+++ b/web/dev/voice-start-measurements.md
@@ -1,0 +1,20 @@
+# 099 startup measurement
+
+Base: main `141a367`. Run `VOICE_CHECK_URL=http://127.0.0.1:49199 node dev/voice-start-check.mjs` against Vite. For the before run, serve the base's `voice.ts` as a temporary `src/voice-baseline.ts` and set `VOICE_START_MODULE=/src/voice-baseline.ts`; remove the temporary module afterwards. No host or transcription request is involved.
+
+Milliseconds from the button's click handler, first take / repeat take in the same page. These are individual observations, not percentile guarantees. The harness asserts capture starts before recording UI and every track ends on cancellation. Chromium uses a generated continuous 440 Hz WAV from sample zero through its native fake capture device; Firefox uses its native fake device. WebKit's public Playwright permission API does not grant microphone access (the native attempt returned `blocked`), so its source is an injected oscillator MediaStream; MediaRecorder, AudioContext and analyser remain native. No physical microphone timing or iOS Safari claim; no simulator was booted.
+
+| Engine / version | Revision | Stream resolves | Recorder starts | Context running | First analyser read | First nonzero sample | First frame callback | Nonzero drawn callback | First dataavailable |
+|---|---|---|---|---|---|---|---|---|---|
+| Chromium 151.0.7922.34 | Before | 111.7 / 22.6 | 112.6 / 22.8 | 113 / 23 | 163.1 / 73.4 | 163.1 / 73.4 | 112.9 / 22.9 | 186.2 / 73.5 | 412.8 / 314 |
+| Chromium 151.0.7922.34 | After | 137.6 / 21.7 | 137.8 / 21.8 | 110.4 / 6.9 | 138.1 / 21.9 | 190.5 / 77 | 139.1 / 21.9 | 190.6 / 77.1 | 436.7 / 318.3 |
+| Firefox 153.0 | Before | 56 / 1 | 57 / 1 | 1049 / 59 | 109 / 59 | 1070 / 112 | 63 / 14 | 1071 / 112 | 322 / 256 |
+| Firefox 153.0 | After | 65 / 1 | 65 / 1 | 89 / 28 | 65 / 1 | 138 / 73 | 77 / 19 | 138 / 73 | 323 / 263 |
+| WebKit 26.5, oscillator source | Before | 18 / 3 | 22 / 5 | 22 / 5 | 74 / 56 | 74 / 106 | 22 / 15 | 75 / 106 | 273 / 256 |
+| WebKit 26.5, oscillator source | After | 23 / 5 | 24 / 5 | 24 / 5 | 24 / 5 | 126 / 65 | 24 / 13 | 126 / 65 | 276 / 260 |
+
+The Firefox first-take delay was in the monitoring context: recording started at 57 ms and delivered a chunk at 322 ms, but the analyser did not receive signal until 1070 ms. Activating the context within the click removed that roughly one-second delay. Capture already preceded recording UI; that ordering is now tested. The first analyser read now happens immediately after starting capture, with another read on the first animation frame, then 20 Hz updates. A pending permission prompt shows “Waiting for the microphone…” / “正在等待麦克风…” with Cancel, no timer or waveform. Stop releases tracks immediately, before the asynchronous encoded clip callback.
+
+`dataavailable` measures encoded chunk delivery (250 ms timeslice), not first capture. First nonzero analyser sample is an observable upper bound on signal availability, not a timestamp of the microphone's first physical sample. All three repeat-tap observed signal/draw times are below 150 ms; this is not a hardware/browser latency guarantee. Frame timestamps are requestAnimationFrame callbacks after the harness SVG update, not compositor presentation timestamps. Chromium's default fake source has initial silence, so earlier exploratory runs without the continuous WAV showed ~500 ms of silence despite ~22 ms recorder startup; those are not application input lag. The native WebKit permission test was blocked; oscillator timing does not measure its permission/device acquisition.
+
+Screenshots from the real app state matrix: `/tmp/infercat-099-shots/waiting-390-en.png`, `waiting-390-zh.png`, and `recording-390-en.png`. The matrix checks pending permission, late permission after Cancel, and the existing recording/transcription/playback/error/offline states at 390 and 1280 in both languages.

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -15,6 +15,7 @@ export const en = {
   app_mic: "Speak",
   app_mic_stop: "Stop recording",
   app_type_or_speak: "Type or speak…",
+  app_voice_waiting: "Waiting for the microphone…",
   app_voice_cancel: "Cancel",
   app_voice_recording: "{m}:{ss}",
   app_voice_transcribing: "{seconds} s · transcribing on {host}…",

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -15,6 +15,7 @@ export const zh = {
   app_mic: "说话",
   app_mic_stop: "停止录音",
   app_type_or_speak: "打字或说话…",
+  app_voice_waiting: "正在等待麦克风…",
   app_voice_cancel: "取消",
   app_voice_recording: "{m}:{ss}",
   app_voice_transcribing: "{seconds} 秒 · 正在由 {host} 转写…",

--- a/web/src/ui/Chat.tsx
+++ b/web/src/ui/Chat.tsx
@@ -1096,6 +1096,7 @@ function Composer({
 function RecordingLine({ state, host, onCancel }: { state: RecordingState; host: string; onCancel: () => void }) {
   if (state.kind === 'idle' || state.kind === 'blocked' || state.kind === 'missing') return null;
   const who = host || tr('app_the_host_lowercase');
+  if (state.kind === 'requesting') return <div className="spoken" role="status"><span>{tr('app_voice_waiting')}</span><button className="ghost tiny" onClick={onCancel}>{tr('app_voice_cancel')}</button></div>;
   if (state.kind === 'error') return <p className="spoken bad" role="status">{tr('app_voice_failed', { host: who, seconds: Math.round(state.seconds), title: describeError(state.error, host).title })}</p>;
   if (state.kind === 'done') {
     const count = voiceWords(state.text);

--- a/web/src/voice.test.ts
+++ b/web/src/voice.test.ts
@@ -30,6 +30,8 @@ describe('voice recorder ownership', () => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'performance'] });
     FakeRecorder.instances = []; FakeContext.level = .1;
     FakeRecorder.isTypeSupported = (mime) => mime.includes('webm');
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => setTimeout(cb, 0));
+    vi.stubGlobal('cancelAnimationFrame', (id: ReturnType<typeof setTimeout>) => clearTimeout(id));
     vi.stubGlobal('MediaRecorder', FakeRecorder); vi.stubGlobal('AudioContext', FakeContext);
     vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn(async () => stream) } });
     stopTrack.mockClear();
@@ -51,6 +53,28 @@ describe('voice recorder ownership', () => {
     expect(states).toContainEqual({ kind: 'transcribing', seconds: 300 });
     expect(stopTrack).toHaveBeenCalled();
     recorder.clear(); expect(recorder.state.kind).toBe('idle');
+  });
+  it('activates audio on the gesture and starts capture before showing recording', async () => {
+    let permit!: (value: unknown) => void;
+    let activated = false;
+    class GestureContext extends FakeContext { resume = vi.fn(async () => { activated = true; }); }
+    vi.stubGlobal('AudioContext', GestureContext);
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: () => {
+      expect(activated).toBe(true);
+      return new Promise((resolve) => { permit = resolve; });
+    } } });
+    const recorder = new VoiceRecorder(vi.fn(), (state) => {
+      if (state.kind === 'recording') {
+        expect(FakeRecorder.instances.at(-1)?.state).toBe('recording');
+        expect(state.waveform.at(-1)).toBeGreaterThan(0);
+      }
+    });
+    const pending = recorder.start();
+    expect(recorder.state.kind).toBe('requesting');
+    permit(stream); await pending;
+    expect(recorder.state.kind).toBe('recording');
+    recorder.cancel();
+    expect(stopTrack).toHaveBeenCalledTimes(1);
   });
   it('cancel never uploads and a delayed old stop cannot stop a new take', async () => {
     const upload = vi.fn(async () => 'hello');

--- a/web/src/voice.ts
+++ b/web/src/voice.ts
@@ -43,6 +43,7 @@ export class VoiceRecorder {
   private context: AudioContext | null = null;
   private tick: ReturnType<typeof setInterval> | undefined;
   private cap: ReturnType<typeof setTimeout> | undefined;
+  private frame: number | undefined;
   private started = 0;
   private stoppedSeconds: number | null = null;
   constructor(private readonly upload: (clip: Blob, signal: AbortSignal) => Promise<string>, private readonly changed: (state: RecordingState) => void) {}
@@ -55,6 +56,9 @@ export class VoiceRecorder {
       if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
         this.emit({ kind: 'missing' }); return;
       }
+      // Activate audio on the click, before awaiting the permission prompt.
+      const context = new AudioContext(); this.context = context;
+      void context.resume().catch(() => {});
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       if (controller.signal.aborted) { stream.getTracks().forEach((track) => track.stop()); return; }
       this.stream = stream;
@@ -62,12 +66,6 @@ export class VoiceRecorder {
       const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
       this.recorder = recorder;
       const chunks: Blob[] = [];
-      const context = new AudioContext(); this.context = context;
-      void context.resume().catch(() => {});
-      const analyser = context.createAnalyser(); analyser.fftSize = 1024;
-      context.createMediaStreamSource(stream).connect(analyser);
-      const samples = new Float32Array(analyser.fftSize);
-      const waveform: number[] = Array(60).fill(0);
       recorder.ondataavailable = (event) => { if (!controller.signal.aborted && event.data.size) chunks.push(event.data); };
       recorder.onerror = () => {
         if (!controller.signal.aborted) { this.cancel(); this.emit({ kind: 'error', seconds: this.elapsed(), error: new Error('Microphone recording failed.') }); }
@@ -86,13 +84,23 @@ export class VoiceRecorder {
       };
       this.started = performance.now(); this.stoppedSeconds = null;
       recorder.start(250);
-      this.emit({ kind: 'recording', seconds: 0, level: 0, waveform: [...waveform] });
-      this.tick = setInterval(() => {
+      const analyser = context.createAnalyser(); analyser.fftSize = 1024;
+      context.createMediaStreamSource(stream).connect(analyser);
+      const samples = new Float32Array(analyser.fftSize);
+      const waveform: number[] = Array(60).fill(0);
+      const sample = () => {
         analyser.getFloatTimeDomainData(samples);
         const rms = Math.sqrt(samples.reduce((sum, n) => sum + n * n, 0) / samples.length);
         const level = Math.min(1, rms * 4); waveform.push(level); waveform.shift();
         this.emit({ kind: 'recording', seconds: this.elapsed(), level, waveform: [...waveform] });
-      }, 50);
+      };
+      // Read immediately, then on the first paint; no empty interval before feedback.
+      sample();
+      this.frame = requestAnimationFrame(() => {
+        if (controller.signal.aborted || recorder.state !== 'recording') return;
+        sample();
+        this.tick = setInterval(sample, 50);
+      });
       this.cap = setTimeout(() => this.stop(), RECORDING_LIMIT_SECONDS * 1000);
     } catch (error) {
       if (controller.signal.aborted) return;
@@ -104,7 +112,8 @@ export class VoiceRecorder {
   private elapsed(): number { return Math.min(RECORDING_LIMIT_SECONDS, Math.max(0, (performance.now() - this.started) / 1000)); }
   stop(): void {
     clearInterval(this.tick); clearTimeout(this.cap);
-    if (this.recorder?.state === 'recording') { this.stoppedSeconds = this.elapsed(); this.recorder.stop(); }
+    if (this.frame !== undefined) cancelAnimationFrame(this.frame);
+    if (this.recorder?.state === 'recording') { this.stoppedSeconds = this.elapsed(); this.recorder.stop(); this.releaseMedia(); }
   }
   cancel(): void {
     this.controller?.abort(); this.controller = null;
@@ -114,6 +123,7 @@ export class VoiceRecorder {
   clear(): void { if (this.state.kind === 'done' || this.state.kind === 'error' || this.state.kind === 'blocked' || this.state.kind === 'missing') this.emit({ kind: 'idle' }); }
   private releaseMedia(): void {
     clearInterval(this.tick); clearTimeout(this.cap);
+    if (this.frame !== undefined) cancelAnimationFrame(this.frame);
     this.stream?.getTracks().forEach((track) => track.stop()); this.stream = null;
     void this.context?.close().catch(() => {}); this.context = null; this.recorder = null;
   }


### PR DESCRIPTION
Fixes delayed microphone feedback at the start of recording. AudioContext is resumed during the click, capture starts before analyser setup and recording UI, and sampling begins immediately plus on the first animation frame. While permission is pending, the composer says “Waiting for the microphone…” with Cancel; Stop releases tracks immediately.

The before/after harness found Firefox capturing at 57 ms but not receiving analyser signal until 1070 ms. After the fix that signal arrived at 138 ms. Repeat-tap signal feedback was 77 ms Chromium, 73 ms Firefox, and 65 ms WebKit. The committed measurement report distinguishes stream readiness, recorder start, context activation, analyser reads, frame callbacks, nonzero signal and encoded chunk delivery. Chromium/Firefox use native fake capture devices; WebKit uses an oscillator MediaStream because its microphone permission cannot be granted by the public Playwright API. These are observed media-pipeline timings, not physical microphone or iOS guarantees.

Validation: make check OK; full web suite 389 passed / 0 failed / 0 skipped; voice UI matrix 185/0/0 across EN/ZH at 390/1280; six native-media timing observations with capture-before-UI and track-release assertions. One matrix run timed out under concurrent load; its fixed-delay recording action now waits for the actual state and the rerun passed. Font check: 546 CJK glyphs present, zero missing; no font change.

L2, size 1, one commit. Base `141a367a02f536c772b877207fbd07344962c108`; tip `d7a5734a053336a4e84e93c7ddb7a158b0c0c365`. Binary diff SHA-256 `c73cc16990b559ca46792f38752c9304dfc349b9bc6e8822ff13971c1b9abece`. Source +23/-10; tests/harness +91/-1; measurement documentation +20/-0; total +134/-11 in 8 files. Zero new concepts or dependencies; no numeric LOC ceiling stated. No deployment in this PR.
