### PR TITLE
100: resident audio.cpp ASR try-out with measured Metal speed

### DIFF
--- a/hack/asr-shim/README.md
+++ b/hack/asr-shim/README.md
@@ -1,0 +1,41 @@
+# audio.cpp ASR proof shim (100)
+
+One local model, one CLI process per request. Python standard library only; no ML Python packages. Bind is loopback-only. This is a try-out tool, not a production server. `/v1/models` advertises `FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0`; multipart `/v1/audio/transcriptions` accepts `file`, optional `language` (`auto`, `zh`, `en`, `ja`), and `response_format` (`json` or `verbose_json`). The latter includes duration measured from decoded PCM; ordinary JSON contains only `text`.
+
+## Pinned build
+
+Verified on macOS arm64 (M5 Max, 64 GiB), Python 3.9.6, CMake 3.31.6 and FFmpeg 9.0.1. CMake/FFmpeg are build/audio tools, not ML dependencies.
+
+```sh
+git clone https://github.com/0xShug0/audio.cpp.git
+git -C audio.cpp checkout fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416
+cmake -S audio.cpp -B audio.cpp/build/cpu -DCMAKE_BUILD_TYPE=Release \
+  -DENGINE_ENABLE_METAL=OFF -DENGINE_ENABLE_OPENMP=OFF \
+  -DAUDIOCPP_DEPLOYMENT_BUILD=ON -DAUDIOCPP_MODEL_SET=custom \
+  -DAUDIOCPP_MODELS=fun_asr_nano
+cmake --build audio.cpp/build/cpu --target audiocpp_cli -j 4
+curl -fL https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-GGUF/resolve/ce72677f84900f0dc57f498ace253bfb3c9155b6/fun-asr-nano-2512-q8_0.gguf -o fun-asr-nano-2512-q8_0.gguf
+# Verify before running: 1,045,334,432 bytes; SHA-256:
+# 4d727357574b079b7f43336b2930f39da086ca02f5d8d50872090b4c1c3d5e0a
+shasum -a 256 fun-asr-nano-2512-q8_0.gguf
+python3 hack/asr-shim/server.py --cli "$PWD/audio.cpp/build/cpu/bin/audiocpp_cli" \
+  --model "$PWD/fun-asr-nano-2512-q8_0.gguf" --port 18082
+```
+
+Point the existing isolated Infercat host at `--upstream-transcribe http://127.0.0.1:18082 --upstream-transcribe-model FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0`, and include that id in its host model allowlist. Preserve its data directory to preserve invites. No key or invite belongs in this directory.
+
+FFmpeg decodes WebM/MP4/MP3 uploads to mono 16 kHz PCM WAV; audio.cpp consumes WAV. Each request has a private temporary directory, removed on completion/failure. Maximum upload is 25 MiB, decoded duration 300 seconds, one CLI process at a time; extra requests get 429. Decode/CLI timeouts are 30/300 seconds and failures return 502. No audio/transcript is retained and CLI stdout/stderr is discarded. No streaming, timestamps, resident-model cache, backend framework, or alternate decoder.
+
+## Check
+
+```sh
+python3 hack/asr-shim/check.py http://127.0.0.1:18082 /path/to/english.wav /path/to/mandarin.webm
+```
+
+The test expects the spike's public Mandarin sample (5.616 seconds), encoded as WebM: [publisher sample](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512/resolve/main/example/zh.mp3). It checks discovery, JSON/verbose JSON, WAV/WebM decoding, unknown route, missing body/file and unsupported response format. Measured: 7 passed / 0 failed / 0 skipped. The private PM report is `docs/spikes/100-asr.md` in infercat-pm.
+
+## Runtime and licence boundaries
+
+[audio.cpp at the pin](https://github.com/0xShug0/audio.cpp/tree/fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416) has Metal support, but this build explicitly disables it; this spike verifies CPU only. Its [Fun-ASR guide](https://github.com/0xShug0/audio.cpp/blob/fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416/docs/models/fun_asr_nano.md) documents CPU/CUDA. No NVIDIA result is claimed.
+
+The [GGUF model card](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-GGUF) assigns these weights the **FunASR Model Open Source License v1.1**; the [-hf export](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf) says Apache-2.0. Do not substitute the latter label for this GGUF. The runtime itself is Apache-2.0. No weights or runtime binaries are redistributed here.

--- a/hack/asr-shim/README.md
+++ b/hack/asr-shim/README.md
@@ -1,41 +1,48 @@
-# audio.cpp ASR proof shim (100)
+# Resident audio.cpp ASR proof adapter (100)
 
-One local model, one CLI process per request. Python standard library only; no ML Python packages. Bind is loopback-only. This is a try-out tool, not a production server. `/v1/models` advertises `FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0`; multipart `/v1/audio/transcriptions` accepts `file`, optional `language` (`auto`, `zh`, `en`, `ja`), and `response_format` (`json` or `verbose_json`). The latter includes duration measured from decoded PCM; ordinary JSON contains only `text`.
+One checkpoint in the runtime's own resident server; a small Python standard-library adapter handles browser audio and the gateway response contract. No ML Python packages or model/backend framework. This is a loopback try-out tool, not a production service.
 
-## Pinned build
+`/v1/models` probes the resident runtime. Multipart `/v1/audio/transcriptions` accepts `file`, optional `language` (`auto`, `zh`, `en`, `ja`), and `response_format` (`json` or `verbose_json`). FFmpeg decodes to mono 16 kHz PCM WAV. The adapter passes its private temporary WAV path to the local resident server, returns only `text`, and includes decoded duration for verbose JSON. Model id remains `FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0`.
 
-Verified on macOS arm64 (M5 Max, 64 GiB), Python 3.9.6, CMake 3.31.6 and FFmpeg 9.0.1. CMake/FFmpeg are build/audio tools, not ML dependencies.
+## Reproduce
+
+Verified on M5 Max / 64 GiB, Python 3.9.6, CMake 3.31.6, FFmpeg 9.0.1. In a scratch directory:
 
 ```sh
 git clone https://github.com/0xShug0/audio.cpp.git
 git -C audio.cpp checkout fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416
-cmake -S audio.cpp -B audio.cpp/build/cpu -DCMAKE_BUILD_TYPE=Release \
-  -DENGINE_ENABLE_METAL=OFF -DENGINE_ENABLE_OPENMP=OFF \
+cmake -S audio.cpp -B audio.cpp/build/metal -DCMAKE_BUILD_TYPE=Release \
+  -DENGINE_ENABLE_METAL=ON -DENGINE_ENABLE_OPENMP=OFF \
   -DAUDIOCPP_DEPLOYMENT_BUILD=ON -DAUDIOCPP_MODEL_SET=custom \
   -DAUDIOCPP_MODELS=fun_asr_nano
-cmake --build audio.cpp/build/cpu --target audiocpp_cli -j 4
+cmake --build audio.cpp/build/metal --target audiocpp_server -j 4
 curl -fL https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-GGUF/resolve/ce72677f84900f0dc57f498ace253bfb3c9155b6/fun-asr-nano-2512-q8_0.gguf -o fun-asr-nano-2512-q8_0.gguf
-# Verify before running: 1,045,334,432 bytes; SHA-256:
-# 4d727357574b079b7f43336b2930f39da086ca02f5d8d50872090b4c1c3d5e0a
 shasum -a 256 fun-asr-nano-2512-q8_0.gguf
-python3 hack/asr-shim/server.py --cli "$PWD/audio.cpp/build/cpu/bin/audiocpp_cli" \
-  --model "$PWD/fun-asr-nano-2512-q8_0.gguf" --port 18082
+# Expected 1,045,334,432 bytes; SHA-256:
+# 4d727357574b079b7f43336b2930f39da086ca02f5d8d50872090b4c1c3d5e0a
+# Copy this directory's runtime.example.json beside the GGUF as runtime.json.
+audio.cpp/build/metal/bin/audiocpp_server --config runtime.json
+# In another terminal, from the Infercat repo:
+python3 hack/asr-shim/server.py --runtime-port 18084 --port 18082
 ```
 
-Point the existing isolated Infercat host at `--upstream-transcribe http://127.0.0.1:18082 --upstream-transcribe-model FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0`, and include that id in its host model allowlist. Preserve its data directory to preserve invites. No key or invite belongs in this directory.
+The example binds the runtime to 127.0.0.1:18084, disables its UI, loads eagerly, disables idle unloading, uses Metal with 4 threads, and retains ITN=true / max_tokens=512 / auto 30-second chunks. A CPU comparison uses `ENGINE_ENABLE_METAL=OFF` and `backend: cpu`. GPU/library warmup and model load occur at server startup/first use, not on every take; warm it on representative clips before handing over the invite.
 
-FFmpeg decodes WebM/MP4/MP3 uploads to mono 16 kHz PCM WAV; audio.cpp consumes WAV. Each request has a private temporary directory, removed on completion/failure. Maximum upload is 25 MiB, decoded duration 300 seconds, one CLI process at a time; extra requests get 429. Decode/CLI timeouts are 30/300 seconds and failures return 502. No audio/transcript is retained and CLI stdout/stderr is discarded. No streaming, timestamps, resident-model cache, backend framework, or alternate decoder.
+Point the existing isolated Infercat host at `--upstream-transcribe http://127.0.0.1:18082 --upstream-transcribe-model FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0`, include that id in its host allowlist, and preserve its data directory/invite. The runtime accepts server-local paths and must remain loopback-only; the adapter generates those paths itself and does not accept one from clients.
 
-## Check
+Limits: 25 MiB upload, 300-second decoded audio, one adapter request at a time (extra calls get429), 30-second decode/300-second runtime timeout. Private temporary uploads/WAVs are removed on handled completion/failure. No recording/transcript is logged by the adapter. Server-Timing reports upload+multipart parsing, decode, runtime round trip, and the native preparation/inference timer; inference is a subset of runtime, not additive. No streaming or new persistent audio state.
+
+## Proof and settings
 
 ```sh
 python3 hack/asr-shim/check.py http://127.0.0.1:18082 /path/to/english.wav /path/to/mandarin.webm
+python3 hack/asr-shim/profile.py /path/to/english.wav /path/to/mandarin.webm http://127.0.0.1:18082
 ```
 
-The test expects the spike's public Mandarin sample (5.616 seconds), encoded as WebM: [publisher sample](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512/resolve/main/example/zh.mp3). It checks discovery, JSON/verbose JSON, WAV/WebM decoding, unknown route, missing body/file and unsupported response format. Measured: 7 passed / 0 failed / 0 skipped. The private PM report is `docs/spikes/100-asr.md` in infercat-pm.
+The Mandarin check uses the publisher's [5.616-second sample](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512/resolve/main/example/zh.mp3), encoded as WebM. Seven live route/format checks passed. Same-payload local medians: per-request CPU exec 2286/1891 ms EN/ZH; resident CPU (4 threads) 917/557; resident Metal (4 threads) 214/154. Actual browser tunnel medians (two runs) changed from2653/2123 to519/355 ms; transcripts matched. Initial Metal startup was8.58 s, first inference slower than warm runs, resident RSS about 2.54 GiB. These are short-clip observations, not throughput guarantees.
 
-## Runtime and licence boundaries
+Language follows the request (the app sends UI language; absent means auto). Decoding is greedy argmax; generic CLI beam/temperature/top-k/top-p switches are rejected by this model. No separate punctuation switch exists. ITN=false removed punctuation/capitalization on these clips, so true stays. Lowering max_tokens or disabling chunking did not establish a useful speed gain and risks longer input; defaults remain. Exact settings, raw stage results, licensing, founder verdict and launch-job cleanup are in private `infercat-pm/docs/spikes/100-asr.md`.
 
-[audio.cpp at the pin](https://github.com/0xShug0/audio.cpp/tree/fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416) has Metal support, but this build explicitly disables it; this spike verifies CPU only. Its [Fun-ASR guide](https://github.com/0xShug0/audio.cpp/blob/fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416/docs/models/fun_asr_nano.md) documents CPU/CUDA. No NVIDIA result is claimed.
+## Pins and licence
 
-The [GGUF model card](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-GGUF) assigns these weights the **FunASR Model Open Source License v1.1**; the [-hf export](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf) says Apache-2.0. Do not substitute the latter label for this GGUF. The runtime itself is Apache-2.0. No weights or runtime binaries are redistributed here.
+[audio.cpp pin](https://github.com/0xShug0/audio.cpp/tree/fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416) is Apache-2.0. The [GGUF card](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-GGUF) assigns these weights **FunASR Model Open Source License v1.1**, while the [-hf export](https://huggingface.co/FunAudioLLM/Fun-ASR-Nano-2512-hf) says Apache-2.0; do not substitute that label for this GGUF. No weights/binaries are redistributed. CPU and Metal were measured; NVIDIA was not. F16 was dropped at the founder's direction; Q8_0 stays.

--- a/hack/asr-shim/check.py
+++ b/hack/asr-shim/check.py
@@ -1,0 +1,43 @@
+"""Exercise the real running shim; pass an English WAV and a Mandarin WebM."""
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+base, english, mandarin = sys.argv[1:]
+passed = 0
+
+def call(path, body=None, headers=None):
+    request = urllib.request.Request(base + path, data=body, headers=headers or {})
+    try:
+        response = urllib.request.urlopen(request, timeout=60)
+    except urllib.error.HTTPError as error:
+        response = error
+    return response.status, json.load(response)
+
+def upload(path, fmt):
+    boundary = 'asr-shim-check'
+    body = (f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="clip"\r\n\r\n'.encode()
+            + Path(path).read_bytes()
+            + f'\r\n--{boundary}\r\nContent-Disposition: form-data; name="response_format"\r\n\r\n{fmt}\r\n--{boundary}--\r\n'.encode())
+    return call('/v1/audio/transcriptions', body, {'Content-Type': 'multipart/form-data; boundary=' + boundary})
+
+status, models = call('/v1/models')
+assert status == 200 and models['data'][0]['id'] == 'FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0'
+passed += 1
+status, result = upload(english, 'json')
+assert status == 200 and set(result) == {'text'} and result['text']
+passed += 1
+status, result = upload(mandarin, 'verbose_json')
+assert status == 200 and result['text'] and 5 < result['duration'] < 6
+passed += 1
+assert call('/missing')[0] == 404
+passed += 1
+assert call('/v1/audio/transcriptions', b'')[0] == 413
+passed += 1
+assert call('/v1/audio/transcriptions', b'x', {'Content-Type': 'text/plain'})[0] == 400
+passed += 1
+assert upload(english, 'srt')[0] == 400
+passed += 1
+print(f'ASR shim: {passed} passed / 0 failed / 0 skipped')

--- a/hack/asr-shim/profile.py
+++ b/hack/asr-shim/profile.py
@@ -1,0 +1,27 @@
+"""Same-payload loopback comparison; output raw times, never a rounded speed claim."""
+import json
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+english, mandarin, *urls = sys.argv[1:]
+for base in urls:
+    for language, path in [('en', english), ('zh', mandarin)]:
+        boundary = 'asr-profile'
+        body = (f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="clip"\r\n\r\n'.encode()
+                + Path(path).read_bytes()
+                + f'\r\n--{boundary}\r\nContent-Disposition: form-data; name="language"\r\n\r\n{language}\r\n--{boundary}--\r\n'.encode())
+        for run in range(3):
+            request = urllib.request.Request(base + '/v1/audio/transcriptions', data=body,
+                                            headers={'Content-Type': 'multipart/form-data; boundary=' + boundary})
+            start = time.perf_counter()
+            with urllib.request.urlopen(request, timeout=60) as response:
+                result = json.load(response)
+                timings = {item.strip().split(';dur=')[0]: float(item.split(';dur=')[1])
+                           for item in response.headers.get('Server-Timing', '').split(',') if ';dur=' in item}
+            total = (time.perf_counter() - start) * 1000
+            other = total - sum(timings.get(key, 0) for key in ('upload', 'decode', 'runtime'))
+            print(json.dumps({'url': base, 'language': language, 'run': run, 'total_ms': round(total, 3),
+                              'response_transport_other_ms': round(other, 3), 'stages_ms': timings, 'result': result},
+                             ensure_ascii=False), flush=True)

--- a/hack/asr-shim/runtime.example.json
+++ b/hack/asr-shim/runtime.example.json
@@ -1,0 +1,25 @@
+{
+  "host": "127.0.0.1",
+  "port": 18084,
+  "backend": "metal",
+  "threads": 4,
+  "lazy_load": false,
+  "idle_unload_ms": 0,
+  "ui": false,
+  "ui_management": false,
+  "models": [
+    {
+      "id": "FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0",
+      "family": "fun_asr_nano",
+      "path": "fun-asr-nano-2512-q8_0.gguf",
+      "task": "asr",
+      "mode": "offline",
+      "default_request_options": {
+        "enable_itn": "true",
+        "max_tokens": "512",
+        "audio_chunk_mode": "auto",
+        "audio_chunk_seconds": "30"
+      }
+    }
+  ]
+}

--- a/hack/asr-shim/server.py
+++ b/hack/asr-shim/server.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
-"""Loopback proof tool: stdlib HTTP/multipart -> ffmpeg -> pinned audio.cpp CLI."""
+"""Loopback proof tool: stdlib HTTP/multipart -> ffmpeg -> resident pinned audio.cpp server."""
 import argparse
 import json
 import subprocess
 import tempfile
 import threading
+import time
+import urllib.request
 import wave
 from email import policy
 from email.parser import BytesParser
@@ -12,10 +14,10 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 parser = argparse.ArgumentParser(description=__doc__)
-parser.add_argument('--cli', required=True)
-parser.add_argument('--model', required=True)
+parser.add_argument('--runtime-port', type=int, default=18084)
 parser.add_argument('--port', type=int, default=18082)
 args = parser.parse_args()
+RUNTIME = 'http://127.0.0.1:' + str(args.runtime_port)
 MODEL_ID = 'FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0'
 busy = threading.Lock()
 
@@ -25,11 +27,19 @@ class Handler(BaseHTTPRequestHandler):
         self.send_response(status)
         self.send_header('Content-Type', 'application/json')
         self.send_header('Content-Length', str(len(data)))
+        if hasattr(self, 'timings'):
+            self.send_header('Server-Timing', ', '.join(f'{key};dur={value:.3f}' for key, value in self.timings.items()))
         self.end_headers()
         self.wfile.write(data)
 
     def do_GET(self):
-        self.reply(200, {'object': 'list', 'data': [{'id': MODEL_ID, 'object': 'model'}]}) if self.path == '/v1/models' else self.reply(404, {'error': 'Not found'})
+        if self.path != '/v1/models':
+            return self.reply(404, {'error': 'Not found'})
+        try:
+            with urllib.request.urlopen(RUNTIME + '/v1/models', timeout=3) as response:
+                self.reply(200, json.load(response))
+        except OSError:
+            self.reply(502, {'error': 'ASR runtime is unavailable'})
 
     def do_POST(self):
         if self.path != '/v1/audio/transcriptions':
@@ -37,6 +47,7 @@ class Handler(BaseHTTPRequestHandler):
         if not busy.acquire(blocking=False):
             return self.reply(429, {'error': 'ASR is busy'})
         try:
+            started = time.perf_counter(); self.timings = {}
             self.connection.settimeout(30)
             size = int(self.headers.get('Content-Length', '0'))
             if not 0 < size <= 25 * 1024 * 1024:
@@ -48,16 +59,24 @@ class Handler(BaseHTTPRequestHandler):
             language = parts.get('language', b'auto').decode()
             if fmt not in ('json', 'verbose_json') or language not in ('auto', 'zh', 'en', 'ja') or not parts.get('file'):
                 return self.reply(400, {'error': 'Expected file, json/verbose_json, and auto/zh/en/ja language'})
+            self.timings['upload'] = (time.perf_counter() - started) * 1000
             with tempfile.TemporaryDirectory(prefix='asr-shim-') as directory:
-                src, wav, text = (Path(directory) / name for name in ('upload', 'audio.wav', 'text.txt'))
+                src, wav = (Path(directory) / name for name in ('upload', 'audio.wav'))
+                started = time.perf_counter()
                 src.write_bytes(parts['file'])
                 subprocess.run(['ffmpeg', '-nostdin', '-v', 'error', '-protocol_whitelist', 'file,pipe', '-i', str(src), '-t', '301', '-ac', '1', '-ar', '16000', str(wav)], check=True, timeout=30, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 with wave.open(str(wav)) as audio:
                     duration = audio.getnframes() / audio.getframerate()
                 if duration > 300:
                     return self.reply(413, {'error': 'Audio exceeds 300 seconds'})
-                subprocess.run([args.cli, '--task', 'asr', '--family', 'fun_asr_nano', '--model', args.model, '--backend', 'cpu', '--audio', str(wav), '--language', language, '--text-out', str(text)], check=True, timeout=300, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                result = {'text': text.read_text().strip()}
+                self.timings['decode'] = (time.perf_counter() - started) * 1000
+                started = time.perf_counter()
+                request = urllib.request.Request(RUNTIME + '/v1/audio/transcriptions', data=json.dumps({'model': MODEL_ID, 'audio_path': str(wav), 'language': language}).encode(), headers={'Content-Type': 'application/json'})
+                with urllib.request.urlopen(request, timeout=300) as response:
+                    decoded = json.load(response)
+                self.timings['runtime'] = (time.perf_counter() - started) * 1000
+                self.timings['inference'] = decoded['timing']['wall_ms']
+                result = {'text': decoded['text']}
                 if fmt == 'verbose_json':
                     result['duration'] = duration
                 self.reply(200, result)

--- a/hack/asr-shim/server.py
+++ b/hack/asr-shim/server.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Loopback proof tool: stdlib HTTP/multipart -> ffmpeg -> pinned audio.cpp CLI."""
+import argparse
+import json
+import subprocess
+import tempfile
+import threading
+import wave
+from email import policy
+from email.parser import BytesParser
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--cli', required=True)
+parser.add_argument('--model', required=True)
+parser.add_argument('--port', type=int, default=18082)
+args = parser.parse_args()
+MODEL_ID = 'FunAudioLLM/Fun-ASR-Nano-2512-GGUF-Q8_0'
+busy = threading.Lock()
+
+class Handler(BaseHTTPRequestHandler):
+    def reply(self, status, body):
+        data = json.dumps(body, ensure_ascii=False).encode()
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        self.reply(200, {'object': 'list', 'data': [{'id': MODEL_ID, 'object': 'model'}]}) if self.path == '/v1/models' else self.reply(404, {'error': 'Not found'})
+
+    def do_POST(self):
+        if self.path != '/v1/audio/transcriptions':
+            return self.reply(404, {'error': 'Not found'})
+        if not busy.acquire(blocking=False):
+            return self.reply(429, {'error': 'ASR is busy'})
+        try:
+            self.connection.settimeout(30)
+            size = int(self.headers.get('Content-Length', '0'))
+            if not 0 < size <= 25 * 1024 * 1024:
+                return self.reply(413, {'error': 'Expected a body of at most 25 MiB'})
+            mime = ('Content-Type: ' + self.headers.get('Content-Type', '') + '\r\nMIME-Version: 1.0\r\n\r\n').encode()
+            form = BytesParser(policy=policy.default).parsebytes(mime + self.rfile.read(size))
+            parts = {p.get_param('name', header='content-disposition'): p.get_payload(decode=True) for p in form.iter_parts()}
+            fmt = parts.get('response_format', b'json').decode()
+            language = parts.get('language', b'auto').decode()
+            if fmt not in ('json', 'verbose_json') or language not in ('auto', 'zh', 'en', 'ja') or not parts.get('file'):
+                return self.reply(400, {'error': 'Expected file, json/verbose_json, and auto/zh/en/ja language'})
+            with tempfile.TemporaryDirectory(prefix='asr-shim-') as directory:
+                src, wav, text = (Path(directory) / name for name in ('upload', 'audio.wav', 'text.txt'))
+                src.write_bytes(parts['file'])
+                subprocess.run(['ffmpeg', '-nostdin', '-v', 'error', '-protocol_whitelist', 'file,pipe', '-i', str(src), '-t', '301', '-ac', '1', '-ar', '16000', str(wav)], check=True, timeout=30, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                with wave.open(str(wav)) as audio:
+                    duration = audio.getnframes() / audio.getframerate()
+                if duration > 300:
+                    return self.reply(413, {'error': 'Audio exceeds 300 seconds'})
+                subprocess.run([args.cli, '--task', 'asr', '--family', 'fun_asr_nano', '--model', args.model, '--backend', 'cpu', '--audio', str(wav), '--language', language, '--text-out', str(text)], check=True, timeout=300, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                result = {'text': text.read_text().strip()}
+                if fmt == 'verbose_json':
+                    result['duration'] = duration
+                self.reply(200, result)
+        except (ValueError, OSError, subprocess.SubprocessError) as error:
+            self.reply(502, {'error': 'Audio decode or ASR failed: ' + type(error).__name__})
+        finally:
+            busy.release()
+
+ThreadingHTTPServer(('127.0.0.1', args.port), Handler).serve_forever()


### PR DESCRIPTION
Keeps the founder's chosen Q8_0 checkpoint in audio.cpp's own resident Metal server. The thin stdlib adapter decodes browser uploads with FFmpeg and preserves `{text}` / verbose duration, while removing model loading from each take. No ML Python toolkit or backend framework.

Identical-clip comparison: loopback medians (three requests) fell from 2286/1891 ms EN/ZH for CPU exec to 214/154 ms for resident Metal. Actual browser-tunnel medians (two requests) fell from 2653/2123 to 519/355 ms. Transcripts matched. CPU 1/4/8/12-thread and Metal comparisons are recorded; four Metal threads were selected. ITN stays enabled after disabling it removed punctuation; F16 was dropped by the founder.

Validation: seven live adapter checks passed / zero failed / zero skipped; three Python files parsed; 30 runtime observations, 18 stage-profile requests and eight real-tunnel before/after requests completed. No full product gate rerun for this isolated hack-only spike. Numerical Server-Timing stages and profile.py distinguish upload/parsing, decode, runtime/inference and residual transport/setup costs.

Runtime pin fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416 and GGUF checksum unchanged. The model's FunASR Model Open Source License v1.1 differs from the -hf export's Apache-2.0 label. No weights or binaries redistributed. The private PM report includes exact results/settings and the five temporary user launch-job labels, no-plist status and removal command. Founder invite/model id unchanged; no launch host or site deployment touched.

L2 / 100 / size 2 / two commits. Base 243d92e0677ae93532a65be44078422ff89d4abd; tip 5761fe5cbf066211a952e3650a80b94d557a5adf; binary patch SHA256 23eb19f87bba22c1ffc697dc6909a2c86542478524789a3f32ac0dbafd8332d9. Source +113 (adapter 88/config 25), tests +70, docs +48; total +231/-0, five files. One proof-tool concept, zero product concepts; no numeric LOC ceiling stated.
Cleanly rebased onto landed 101 at the PM’s request; the complete binary diff and its hash are identical.
