### PR TITLE
101: keep the microphone warm between visible-chat takes

### DIFF
--- a/web/dev/mic-real-check.mjs
+++ b/web/dev/mic-real-check.mjs
@@ -1,0 +1,19 @@
+import { chromium, firefox } from 'playwright';
+for (const [name, type] of Object.entries({chrome:chromium, firefox})) {
+  const browser = await type.launch(name === 'chrome' ? {channel:'chrome',headless:false,args:['--use-fake-ui-for-media-stream']} : {headless:false,firefoxUserPrefs:{'media.navigator.permission.disabled':true}});
+  try {
+    const page = await browser.newPage();
+    await page.goto('http://127.0.0.1:49101/dev/mic-start.html' + (process.env.MIC_PRODUCT ? '?product' : '')); 
+    for (const warm of [false,true]) {
+      await page.locator('#warm').setChecked(warm);
+      for (let i=0;i<2;i++) {
+        await page.evaluate(()=>{window.result=null;}); await page.click('#record');
+        try { await page.waitForFunction(()=>window.result, null, {timeout:15000}); }
+        catch { console.log(name,warm,i,'permission/device request still pending after 15 s'); break; }
+        console.log(name,warm,i,JSON.stringify(await page.evaluate(()=>window.result)));
+        if(await page.evaluate(()=>!!window.result.error))break;
+      }
+      await page.click('#release');
+    }
+  } finally {await browser.close();}
+}

--- a/web/dev/mic-start-measurements.md
+++ b/web/dev/mic-start-measurements.md
@@ -1,0 +1,34 @@
+# 101 — real microphone, cold and warm
+
+Measured 2026-09-10 on this Mac's **MacBook Pro Microphone**, with installed Chrome 152 and Playwright Firefox 153 using real capture devices (no oscillator, prerecorded capture input or fake device). Audio was not uploaded or retained. Native permission was auto-approved in the isolated browser profiles. Safari WebDriver refused the session because Allow remote automation is disabled; CUA access by Safari name and verified bundle id both returned `cgWindowNotFound`. Safari real-mic measurements remain **unavailable**, not replaced by synthetic WebKit numbers.
+
+Run Vite at 127.0.0.1:49101, then `node dev/mic-real-check.mjs`. The page `dev/mic-start.html` is also manually usable in Safari. `MIC_PRODUCT=1 node dev/mic-real-check.mjs` measures the revised production VoiceRecorder rather than the initial device experiment. Each mode makes two takes in the same page; the keep-warm mode follows the stopped-stream mode, so its first take has already-granted permission but reacquires a closed stream. Only the first stopped-stream take is a fresh page/device run.
+
+Milliseconds from pointerdown. Individual observations, not percentiles or guarantees. `signal` is the first nonzero analyser read. In a warm stream it can be prefilled audio, so **it is not the timestamp of the first newly captured physical sample**. `recorderStarted` is the synchronous MediaRecorder start call. `encodedChunk` is packet delivery, not capture: the device experiment uses 100 ms chunks, the product 250 ms. No spoken-word accuracy claim is inferred from these timestamps.
+
+| Implementation | Browser | Case | Stream resolves | Recorder starts | First analyser read | Signal observed | First encoded chunk |
+|---|---|---|---:|---:|---:|---:|---:|
+| Device experiment, before edits | Chrome 152 | Fresh, stop tracks | 389.2 | 390.3 | 390.4 | 600.7 | 505.2 |
+| Device experiment | Chrome 152 | Repeat, stopped tracks | 77.2 | 77.3 | 77.3 | 170.9 | 184.4 |
+| Device experiment | Chrome 152 | First keep-warm take | 79.9 | 79.9 | 79.9 | 173.8 | 190.4 |
+| Device experiment | Chrome 152 | Warm repeat | 0 | 0 | 0 | 0 | 112.1 |
+| Device experiment | Firefox 153 | Fresh, stop tracks | 104 | 104 | 104 | 1405 | 209 |
+| Device experiment | Firefox 153 | Repeat, stopped tracks | 1 | 1 | 1 | 178 | 108 |
+| Device experiment | Firefox 153 | First keep-warm take | 0 | 0 | 0 | 165 | 108 |
+| Device experiment | Firefox 153 | Warm repeat | 0 | 0 | 0 | 0 | 96 |
+| Revised VoiceRecorder | Chrome 152 | Fresh, stop tracks | 261.4 | 261.8 | 262 | 513 | 557.5 |
+| Revised VoiceRecorder | Chrome 152 | Repeat, stopped tracks | 82.5 | 82.6 | 82.7 | 193.2 | 372.2 |
+| Revised VoiceRecorder | Chrome 152 | First keep-warm take | 83.8 | 83.9 | 84 | 199.4 | 375.1 |
+| Revised VoiceRecorder | Chrome 152 | Warm repeat | reused | 0.1 | 0.2 | 0.2 | 291.8 |
+| Revised VoiceRecorder | Firefox 153 | Fresh, stop tracks | 1099 | 1099 | 1100 | 1436 | 1361 |
+| Revised VoiceRecorder | Firefox 153 | Repeat, stopped tracks | 2 | 2 | 161 | 220 | 262 |
+| Revised VoiceRecorder | Firefox 153 | First keep-warm take | 0 | 1 | 163 | 163 | 259 |
+| Revised VoiceRecorder | Firefox 153 | Warm repeat | reused | 0 | 3 | 3 | 260 |
+
+The real-device cold path remains slow and variable; the fix removes repeated device/context acquisition from subsequent gestures. The controller retains the granted stream and analyser while the chat is visible, stops each MediaRecorder at Stop/Cancel, and releases the stream/context on hide, pagehide, unmount or loss of access. Visibility return never starts a take or requests permission. Pointerdown begins acquisition; keyboard/screen-reader click activation remains supported without a duplicate pointer click. The existing waiting line stays while permission/context activation is pending. Capture starts as soon as the stream is available, before awaiting the monitoring context, so monitoring startup cannot delay the recorder. It does not wait for nonzero amplitude: legitimate silence must remain recordable. Cold-device readiness cannot be proven from nonzero amplitude or from a browser's synthetic initial zero frames.
+
+## Historical founder browser and shell
+
+**Unknown from existing logs.** `internal/usage/usage.go` has no user-agent or client-build fields; the 113 host rows inspected contain neither. The host supplies API responses, not the web shell. No new host telemetry was added to this web-only ticket. PM was asked for the founder's browser/device and whether the waiting line was visible; no answer is assumed.
+
+`web/src/sw.ts` uses network-first navigation and versioned assets; a currently open app can continue executing an older bundle. It intentionally does not call `skipWaiting`, so activation can wait for old windows to close. After the gate deploys, reload online; close all Infercat tabs/PWA windows and reopen to activate a waiting worker. Neither “reload twice” nor the API host's version proves which historical shell the founder ran. The gate must verify the deployed bundle; this candidate does not deploy it.

--- a/web/dev/mic-start.html
+++ b/web/dev/mic-start.html
@@ -1,0 +1,53 @@
+<!doctype html><meta charset="utf-8"><title>101 local real-microphone timing</title>
+<label><input id="warm" type="checkbox"> Keep stream warm between takes</label>
+<button id="record">Record 2 seconds</button><button id="release">Release microphone</button><pre id="result">No microphone requested yet.</pre>
+<script type="module">
+let stream, context, analyser, recorder, frame;
+const out = document.querySelector('#result');
+function release() { cancelAnimationFrame(frame); stream?.getTracks().forEach(t => t.stop()); stream = null; void context?.close(); context = null; }
+document.querySelector('#release').onclick = release;
+document.addEventListener('visibilitychange', () => { if (document.hidden) release(); });
+window.addEventListener('pagehide', release);
+document.querySelector('#record').onpointerdown = async () => {
+  const start = performance.now(); const times = {}; const mark = k => times[k] ??= Math.round((performance.now() - start) * 10) / 10;
+  try {
+    if (!context) { context = new AudioContext(); void context.resume(); }
+    if (!stream) { stream = await navigator.mediaDevices.getUserMedia({audio:true}); analyser = context.createAnalyser(); context.createMediaStreamSource(stream).connect(analyser); }
+    mark('streamReady');
+    recorder = new MediaRecorder(stream); recorder.ondataavailable = () => mark('encodedChunk'); recorder.start(100);
+    mark('recorderStarted'); const samples = new Float32Array(analyser.fftSize);
+    const sample = () => { analyser.getFloatTimeDomainData(samples); mark('firstRead'); if (samples.some(n => n !== 0)) mark('signal'); frame = requestAnimationFrame(sample); };
+    sample();
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    recorder.stop(); cancelAnimationFrame(frame);
+    const result = {userAgent:navigator.userAgent, device:stream.getAudioTracks()[0].label, warm:document.querySelector('#warm').checked, times};
+    if (!result.warm) release();
+    window.result = result; out.textContent = JSON.stringify(result, null, 2);
+  } catch (error) { release(); window.result = {error:error.name, message:error.message}; out.textContent = JSON.stringify(window.result); }
+};
+if (new URLSearchParams(location.search).has('product')) {
+  const { VoiceRecorder } = await import('/src/voice.ts');
+  let times, start, device = '';
+  const mark = key => { if (times) times[key] ??= Math.round((performance.now() - start) * 10) / 10; };
+  const gum = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+  navigator.mediaDevices.getUserMedia = async options => { const value = await gum(options); device = value.getAudioTracks()[0].label; mark('streamReady'); return value; };
+  const NativeRecorder = window.MediaRecorder;
+  window.MediaRecorder = class extends NativeRecorder { start(...args) { mark('recorderStarted'); this.addEventListener('dataavailable', () => mark('encodedChunk')); super.start(...args); } };
+  const read = AnalyserNode.prototype.getFloatTimeDomainData;
+  AnalyserNode.prototype.getFloatTimeDomainData = function (samples) { read.call(this, samples); mark('firstRead'); if (samples.some(n => n !== 0)) mark('signal'); };
+  const owned = new VoiceRecorder(async () => '', () => {});
+  const close = () => owned.release();
+  document.querySelector('#release').onclick = close;
+  document.addEventListener('visibilitychange', () => { if (document.hidden) close(); });
+  window.addEventListener('pagehide', close);
+  document.querySelector('#record').onpointerdown = async () => {
+    start = performance.now(); times = {};
+    await owned.start();
+    if (owned.state.kind !== 'recording') { window.result = {error:owned.state.kind}; out.textContent = JSON.stringify(window.result); close(); return; }
+    await new Promise(resolve => setTimeout(resolve, 2000)); owned.stop();
+    const result = {product:true,userAgent:navigator.userAgent,device,warm:document.querySelector('#warm').checked,times};
+    if (!result.warm) close();
+    window.result = result; out.textContent = JSON.stringify(result, null, 2);
+  };
+}
+</script>

--- a/web/dev/voice-check.mjs
+++ b/web/dev/voice-check.mjs
@@ -15,8 +15,9 @@ async function connected(width, lang, extra = '&transcriptions&speech') {
   const context = await browser.newContext({ viewport: { width, height: width === 390 ? 844 : 800 }, locale: lang === 'zh' ? 'zh-CN' : 'en-US', isMobile: width === 390, hasTouch: width === 390 });
   await context.addInitScript((language) => {
     window.localStorage.setItem('bn.language', JSON.stringify(language));
-    window.__level = .13; window.__micError = ''; window.__tracksStopped = 0;
+    window.__level = .13; window.__micError = ''; window.__tracksStopped = 0; window.__micRequests = 0; window.__takes = 0;
     Object.defineProperty(window.navigator, 'mediaDevices', { configurable: true, value: { getUserMedia: async () => {
+      window.__micRequests++;
       if (window.__holdMic) await new Promise((resolve) => { window.__permitMic = resolve; });
       if (window.__micError) throw new window.DOMException('microphone unavailable', window.__micError);
       return { getTracks: () => [{ stop: () => window.__tracksStopped++ }] };
@@ -24,7 +25,7 @@ async function connected(width, lang, extra = '&transcriptions&speech') {
     window.MediaRecorder = class {
       static isTypeSupported(type) { return type.includes('webm'); }
       state = 'inactive'; mimeType = 'audio/webm;codecs=opus';
-      start() { this.state = 'recording'; }
+      start() { this.state = 'recording'; window.__takes++; }
       stop() { this.state = 'inactive'; window.queueMicrotask(() => { this.ondataavailable?.({ data: new window.Blob(['test recording']) }); this.onstop?.(); }); }
     };
     window.AudioContext = class {
@@ -72,6 +73,11 @@ try {
       await page.waitForTimeout(30);
       check(await page.locator('.composer .spoken').count() === 0, 'late permission stays cancelled');
 
+      await mic.focus(); await mic.press('Space');
+      await page.waitForFunction(() => document.querySelector('.mic')?.getAttribute('aria-pressed') === 'true');
+      check(await page.evaluate(() => window.__takes) === 1, 'keyboard activation starts exactly one take');
+      await page.locator('.composer .spoken button').click();
+      const acquired = await page.evaluate(() => window.__micRequests);
       await page.getByRole('button', { name: lang === 'zh' ? '设置' : 'Settings', exact: true }).click();
       check((await page.locator('.sheet').innerText()).includes('whisper-large-v3') && (await page.locator('.sheet').innerText()).includes('kokoro'), 'Settings names both audio models');
       await page.locator('.sheet .small-print').first().scrollIntoViewIfNeeded(); await shot(page, `settings-${tag}`);
@@ -84,6 +90,7 @@ try {
       await page.waitForFunction(() => document.querySelector('.mic')?.getAttribute('aria-pressed') === 'true');
       await page.waitForTimeout(3100);
       check((await posts(page, '/v1/audio/transcriptions')).length === 0, 'recording stays local');
+      check(await page.evaluate(() => window.__micRequests) === acquired, 'repeat pointerdown reuses the warm stream');
       check(await page.locator('.waveform').count() === 1 && await page.locator('.level').count() === 0, 'waveform replaces rail');
       await shot(page, `recording-${tag}`);
       const wave = await page.locator('.waveform').boundingBox(), cancel = await page.locator('.composer .spoken button').boundingBox();
@@ -124,6 +131,12 @@ try {
       await mic.click(); await page.waitForTimeout(100); await mic.click();
       await page.locator('.composer .spoken button').click(); await page.waitForTimeout(750);
       check(await field.inputValue() === '' && await page.locator('.composer .spoken').count() === 0, 'Cancel discards a late transcription');
+      const stopped = await page.evaluate(() => window.__tracksStopped);
+      await page.evaluate(() => { Object.defineProperty(document, 'hidden', { configurable: true, value: true }); document.dispatchEvent(new window.Event('visibilitychange')); });
+      check(await page.evaluate(() => window.__tracksStopped) > stopped, 'hide releases the granted microphone');
+      const takes = await page.evaluate(() => window.__takes);
+      await page.evaluate(() => { Object.defineProperty(document, 'hidden', { configurable: true, value: false }); document.dispatchEvent(new window.Event('visibilitychange')); });
+      check(await page.evaluate(() => window.__takes) === takes, 'becoming visible never starts a take');
       await page.evaluate(() => { window.__micError = 'NotAllowedError'; }); await mic.click();
       await page.locator('.composer .hint').filter({ hasText: lang === 'zh' ? '麦克风' : 'Microphone blocked' }).waitFor(); await shot(page, `denied-${tag}`);
       await page.evaluate(() => { window.__micError = 'NotFoundError'; }); await mic.click();

--- a/web/dev/voice-start-check.mjs
+++ b/web/dev/voice-start-check.mjs
@@ -46,7 +46,7 @@ for (const [name, type] of Object.entries({ chromium, firefox, webkit })) {
       console.log(name,browser.version(),name === 'webkit' ? 'oscillator-stream' : 'native-fake-device',i===0?'first':'repeat',JSON.stringify(await page.evaluate(()=>({times:window.times,state:window.recorder.state.kind}))));
       assert.equal(await page.evaluate(()=>window.recorder.state.kind), 'recording');
       assert.equal(await page.evaluate(()=>window.times.captureStart <= window.times.recordingUI), true);
-      await page.evaluate(()=>{window.recorder.cancel();window.closeSource?.();});
+      await page.evaluate(()=>{window.recorder.release?.();window.recorder.cancel();window.closeSource?.();});
       if(await page.evaluate(()=>window.stream?.getTracks().some(t=>t.readyState!=='ended')))throw Error('microphone retained');
     }
   }finally{await browser.close();}

--- a/web/src/ui/Chat.tsx
+++ b/web/src/ui/Chat.tsx
@@ -967,12 +967,19 @@ function Composer({
   }));
   const hasVoice = Boolean(voice);
   useEffect(() => {
-    const leave = () => recorder.cancel(); window.addEventListener('pagehide', leave);
-    return () => { window.removeEventListener('pagehide', leave); recorder.cancel(); };
+    const leave = () => recorder.release();
+    const visibility = () => { if (document.hidden) leave(); };
+    window.addEventListener('pagehide', leave); document.addEventListener('visibilitychange', visibility);
+    return () => { window.removeEventListener('pagehide', leave); document.removeEventListener('visibilitychange', visibility); recorder.release(); };
   }, [recorder]);
   useEffect(() => {
-    if ((disabled || sendBlocked || streaming || !hasVoice) && ['requesting', 'recording', 'transcribing'].includes(recorder.state.kind)) recorder.cancel();
+    if (disabled || !hasVoice) recorder.release();
+    else if ((sendBlocked || streaming) && ['requesting', 'recording', 'transcribing'].includes(recorder.state.kind)) recorder.cancel();
   }, [disabled, sendBlocked, streaming, hasVoice, recorder]);
+  const toggleRecording = () => {
+    if (disabled || sendBlocked || streaming || document.hidden) return;
+    if (recorder.state.kind === 'recording') recorder.stop(); else void recorder.start();
+  };
   const editText = (value: string) => { recorder.clear(); onText(value); };
   const sendText = () => { recorder.cancel(); onSend(text); };
   const voiceHint = voice && (recording.kind === 'blocked' ? tr('app_mic_blocked') : recording.kind === 'missing' ? tr('app_no_microphone') : null);
@@ -1067,10 +1074,10 @@ function Composer({
           }}
         />
         {voice && <button className={`attach mic ${recording.kind === 'recording' ? 'on' : ''}`} aria-pressed={recording.kind === 'recording'} aria-label={tr(recording.kind === 'recording' ? 'app_mic_stop' : 'app_mic')}
-          disabled={disabled || sendBlocked || streaming || recording.kind === 'transcribing' || recording.kind === 'requesting'} onClick={() => {
-            if (disabled || sendBlocked || streaming) return;
-            if (recording.kind === 'recording') recorder.stop(); else void recorder.start();
-          }}><svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" aria-hidden="true"><rect x="7" y="2" width="6" height="10" rx="3" /><path d="M4 9.5a6 6 0 0 0 12 0M10 15.5V18M7 18h6" /></svg></button>}
+          disabled={disabled || sendBlocked || streaming || recording.kind === 'transcribing' || recording.kind === 'requesting'}
+          onPointerDown={(event) => { if (event.button === 0) toggleRecording(); }}
+          onPointerCancel={() => recorder.cancel()}
+          onClick={(event) => { if (event.detail === 0) toggleRecording(); }}><svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" aria-hidden="true"><rect x="7" y="2" width="6" height="10" rx="3" /><path d="M4 9.5a6 6 0 0 0 12 0M10 15.5V18M7 18h6" /></svg></button>}
         {streaming ? (
           <button className="primary small" onClick={onStop}>
             {tr('app_stop')}

--- a/web/src/voice.test.ts
+++ b/web/src/voice.test.ts
@@ -37,7 +37,7 @@ describe('voice recorder ownership', () => {
     stopTrack.mockClear();
   });
   afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
-  it('records level/time, stops at five minutes, transcribes once and releases media', async () => {
+  it('records level/time, stops at five minutes and retains the granted stream until release', async () => {
     const upload = vi.fn(async () => 'hello');
     const states: RecordingState[] = [];
     const recorder = new VoiceRecorder(upload, (s) => states.push(s));
@@ -51,7 +51,8 @@ describe('voice recorder ownership', () => {
     expect(upload).toHaveBeenCalledTimes(1);
     expect(recorder.state).toEqual({ kind: 'done', seconds: 300, text: 'hello' });
     expect(states).toContainEqual({ kind: 'transcribing', seconds: 300 });
-    expect(stopTrack).toHaveBeenCalled();
+    expect(stopTrack).not.toHaveBeenCalled();
+    recorder.release(); expect(stopTrack).toHaveBeenCalled();
     recorder.clear(); expect(recorder.state.kind).toBe('idle');
   });
   it('activates audio on the gesture and starts capture before showing recording', async () => {
@@ -73,8 +74,32 @@ describe('voice recorder ownership', () => {
     expect(recorder.state.kind).toBe('requesting');
     permit(stream); await pending;
     expect(recorder.state.kind).toBe('recording');
-    recorder.cancel();
-    expect(stopTrack).toHaveBeenCalledTimes(1);
+    recorder.cancel(); expect(stopTrack).not.toHaveBeenCalled();
+    recorder.release(); expect(stopTrack).toHaveBeenCalledTimes(1);
+  });
+  it('keeps one granted stream across stopped/cancelled takes, releases on hide, and never starts on return', async () => {
+    const acquire = vi.mocked(navigator.mediaDevices.getUserMedia);
+    const upload = vi.fn(async () => 'hello');
+    const recorder = new VoiceRecorder(upload, () => {});
+    expect(acquire).not.toHaveBeenCalled();
+    await recorder.start(); recorder.stop(); await flush();
+    expect(acquire).toHaveBeenCalledTimes(1); expect(stopTrack).not.toHaveBeenCalled();
+    await recorder.start(); recorder.cancel(); await flush();
+    expect(acquire).toHaveBeenCalledTimes(1); expect(upload).toHaveBeenCalledTimes(1);
+    recorder.release(); expect(stopTrack).toHaveBeenCalledTimes(1);
+    const takes = FakeRecorder.instances.length;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeRecorder.instances).toHaveLength(takes); expect(recorder.state.kind).toBe('idle');
+    await recorder.start(); expect(acquire).toHaveBeenCalledTimes(2);
+    recorder.release();
+  });
+  it('hiding during a pending permission grant closes the late stream without a take', async () => {
+    let grant!: (value: unknown) => void;
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: () => new Promise((resolve) => { grant = resolve; }) } });
+    const recorder = new VoiceRecorder(vi.fn(), () => {});
+    const pending = recorder.start(); recorder.release(); grant(stream); await pending;
+    expect(FakeRecorder.instances).toHaveLength(0); expect(stopTrack).toHaveBeenCalledTimes(1);
+    expect(recorder.state.kind).toBe('idle');
   });
   it('cancel never uploads and a delayed old stop cannot stop a new take', async () => {
     const upload = vi.fn(async () => 'hello');

--- a/web/src/voice.ts
+++ b/web/src/voice.ts
@@ -41,6 +41,7 @@ export class VoiceRecorder {
   private recorder: MediaRecorder | null = null;
   private stream: MediaStream | null = null;
   private context: AudioContext | null = null;
+  private analyser: AnalyserNode | null = null;
   private tick: ReturnType<typeof setInterval> | undefined;
   private cap: ReturnType<typeof setTimeout> | undefined;
   private frame: number | undefined;
@@ -50,16 +51,19 @@ export class VoiceRecorder {
   private emit(state: RecordingState): void { this.state = state; this.changed(state); }
   async start(): Promise<void> {
     this.cancel();
+    if (this.stream?.getTracks().some((track) => track.readyState === 'ended')) this.release();
     const controller = new AbortController(); this.controller = controller;
     this.emit({ kind: 'requesting' });
     try {
       if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
         this.emit({ kind: 'missing' }); return;
       }
-      // Activate audio on the click, before awaiting the permission prompt.
-      const context = new AudioContext(); this.context = context;
-      void context.resume().catch(() => {});
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      // The visible chat retains its granted stream; no take exists until this gesture.
+      const context = this.context ?? new AudioContext(); this.context = context;
+      const resumed = context.resume();
+      // Attach a rejection handler now, even while a permission prompt is pending.
+      void resumed.catch(() => {});
+      const stream = this.stream ?? await navigator.mediaDevices.getUserMedia({ audio: true });
       if (controller.signal.aborted) { stream.getTracks().forEach((track) => track.stop()); return; }
       this.stream = stream;
       const mimeType = recordingMime();
@@ -72,7 +76,7 @@ export class VoiceRecorder {
       };
       recorder.onstop = () => {
         if (controller.signal.aborted) { chunks.length = 0; return; }
-        const seconds = this.stoppedSeconds ?? this.elapsed(); this.releaseMedia();
+        const seconds = this.stoppedSeconds ?? this.elapsed(); this.finishTake();
         const clip = new Blob(chunks, { type: recorder.mimeType || mimeType });
         chunks.length = 0;
         this.emit({ kind: 'transcribing', seconds });
@@ -84,8 +88,15 @@ export class VoiceRecorder {
       };
       this.started = performance.now(); this.stoppedSeconds = null;
       recorder.start(250);
-      const analyser = context.createAnalyser(); analyser.fftSize = 1024;
-      context.createMediaStreamSource(stream).connect(analyser);
+      this.cap = setTimeout(() => this.stop(), RECORDING_LIMIT_SECONDS * 1000);
+      if (!this.analyser) {
+        this.analyser = context.createAnalyser(); this.analyser.fftSize = 1024;
+        context.createMediaStreamSource(stream).connect(this.analyser);
+      }
+      const analyser = this.analyser;
+      // Capture already owns the stream; keep the waiting line while audio wakes up.
+      await resumed;
+      if (controller.signal.aborted || recorder.state !== 'recording') return;
       const samples = new Float32Array(analyser.fftSize);
       const waveform: number[] = Array(60).fill(0);
       const sample = () => {
@@ -101,10 +112,9 @@ export class VoiceRecorder {
         sample();
         this.tick = setInterval(sample, 50);
       });
-      this.cap = setTimeout(() => this.stop(), RECORDING_LIMIT_SECONDS * 1000);
     } catch (error) {
       if (controller.signal.aborted) return;
-      this.releaseMedia();
+      this.release();
       const name = error instanceof Error ? error.name : '';
       this.emit(name === 'NotAllowedError' || name === 'SecurityError' ? { kind: 'blocked' } : name === 'NotFoundError' || name === 'NotSupportedError' ? { kind: 'missing' } : { kind: 'error', seconds: 0, error });
     }
@@ -113,19 +123,24 @@ export class VoiceRecorder {
   stop(): void {
     clearInterval(this.tick); clearTimeout(this.cap);
     if (this.frame !== undefined) cancelAnimationFrame(this.frame);
-    if (this.recorder?.state === 'recording') { this.stoppedSeconds = this.elapsed(); this.recorder.stop(); this.releaseMedia(); }
+    if (this.recorder?.state === 'recording') { this.stoppedSeconds = this.elapsed(); this.recorder.stop(); this.finishTake(); }
   }
   cancel(): void {
     this.controller?.abort(); this.controller = null;
     if (this.recorder?.state === 'recording') this.recorder.stop();
-    this.releaseMedia(); this.emit({ kind: 'idle' });
+    this.finishTake(); this.emit({ kind: 'idle' });
   }
   clear(): void { if (this.state.kind === 'done' || this.state.kind === 'error' || this.state.kind === 'blocked' || this.state.kind === 'missing') this.emit({ kind: 'idle' }); }
-  private releaseMedia(): void {
+  /** Hide, unmount, or loss of access ends the permission-owned warm stream. */
+  release(): void {
+    this.cancel();
+    this.stream?.getTracks().forEach((track) => track.stop()); this.stream = null;
+    void this.context?.close().catch(() => {}); this.context = null; this.analyser = null;
+  }
+  private finishTake(): void {
     clearInterval(this.tick); clearTimeout(this.cap);
     if (this.frame !== undefined) cancelAnimationFrame(this.frame);
-    this.stream?.getTracks().forEach((track) => track.stop()); this.stream = null;
-    void this.context?.close().catch(() => {}); this.context = null; this.recorder = null;
+    this.recorder = null;
   }
 }
 


### PR DESCRIPTION
Keeps the microphone stream and audio context warm after the first grant while the chat is visible. Pointerdown starts a take; keyboard activation remains supported. Stop/Cancel ends the recorder, while hide/pagehide/unmount or loss of access releases the stream. Returning to the tab never starts recording or reacquires permission without a gesture.

Real built-in microphone observations on this Mac support the change: revised VoiceRecorder warm repeat starts at 0.1 ms in Chrome 152 and 0 ms in Firefox 153; first analyser reads at 0.2/3 ms. Cold acquisition remains variable (up to ~1.4 s to nonzero signal). The committed table distinguishes stream resolution, recorder start, analyser reads and encoded chunk delivery; warm analyser data is not presented as the first new physical sample. The existing waiting line remains during permission/context activation, and capture starts before waiting for the monitoring context.

Evidence gaps for the gate: Safari WebDriver requires disabled remote automation; native CUA access returned cgWindowNotFound. No real-Safari result is claimed. Existing host logs lack user-agent/client-build fields, so the founder's historical browser and stale-shell status cannot be reconstructed. These gaps were contested with the PM. No deployment was performed.

Validation: make check OK; full web suite 391 passed /0 failed /0 skipped; voice UI 201/0/0 at 390/1280 EN/ZH, including keyboard single activation, pointerdown warm reuse, hide/release, and no automatic recording on visibility return. Native Chrome/Firefox microphone experiment and revised-controller comparison are documented in web/dev/mic-start-measurements.md. No audio from these measurements was uploaded or retained.

L2 / size 2. Base 845b51c608918efddcce889d87738bc5a19ab853 (079 +099); tip 243d92e0677ae93532a65be44078422ff89d4abd. Binary diff SHA-256 5cb6454010131b0e315cf31ade46fb5918d05671bffbb2daa9e4ca6593e3bdc6. Source +43/-21, tests/harness +117/-7, measurement docs +34/-0; total +194/-28 in 8 files. Zero new user concepts, no numeric LOC ceiling stated.
