### PR TITLE
102: honour Stop during microphone startup

### DIFF
--- a/web/dev/102-stop-measurements.md
+++ b/web/dev/102-stop-measurements.md
@@ -1,0 +1,70 @@
+# 102 — Stop during microphone startup
+
+Base 243d92e. The deterministic failure is the pending-stream window: Composer disabled the mic for `requesting`, its toggle treated that state as Start, and `VoiceRecorder.stop()` did nothing without a MediaRecorder. The delayed-permission regression fails on the baseline. The fix leaves the pending mic enabled and labelled with existing Stop copy, centralizes toggle semantics, and remembers Stop until stream resolution. A Stop before any audio can exist becomes an idle cancellation as soon as the stream/recorder arrives; Cancel aborts; a take already capturing while AudioContext resumes is stopped normally. Empty blobs never upload. Warm ownership/release behavior from 101 is unchanged.
+
+Six pending/warm action cases, plus three context-resume action cases and empty-blob coverage, pass. Complete voice unit suite 32/0/0; full web 403/0/0; UI matrix 229/0/0 across 390/1280 EN/ZH; make check OK. No new copy, host change or ASR padding is part of 102.
+
+## First-data and delayed-permission addenda
+
+The founder subsequently supplied a cold Safari take: 1.94 s recorder start after a permission prompt, 2.83 s measured versus 2.12 s decoded with 200 ms leading quiet. His warm take started at1 ms, measured2.11 s, decoded2.12 s, no leading quiet. These are founder-reported observations recorded in ticket102, not additional driven runs by the engineer.
+
+The final candidate retains `requesting` with an idle waveform on a cold stream until its first nonempty MediaRecorder chunk **and** AudioContext readiness. The counter begins at that chunk; empty chunks do nothing. A retained stream that has delivered data starts its next display immediately; release clears that readiness. Stop/Cancel remain effective throughout. The mic's `on` class and `aria-pressed` derive only from `RecordingState.kind === 'recording'`, never a tap-local flag. A delayed grant and one Stop is covered in the real Composer matrix, including a screenshot while native capture has started but no chunk has arrived. No site permission setting was changed.
+
+| Final candidate, real mic | Recorder start | First chunk | Recording shown | Stop result |
+|---|---:|---:|---:|---|
+| Chrome cold |212 ms|488.7 ms|488.9 ms|done|
+| Chrome warm |0.1 ms|300.4 ms|0.2 ms|done|
+| Chrome reopened |78.6 ms|361.5 ms|361.6 ms|done|
+| Firefox cold |94 ms|360 ms|1163 ms|done|
+| Firefox warm |0 ms|259 ms|3 ms|done|
+| Firefox reopened |1 ms|264 ms|265 ms|done|
+
+Warm added wait is therefore effectively zero (0.1 ms Chrome,3 ms Firefox between recorder start and display). Cold Chrome hides276.9 ms before first data; cold Firefox retains waiting through its later context readiness. A nonempty container chunk is the ruled readiness signal, **not proof of a first physical microphone sample**. Encoders may buffer a timeslice or deliver headers before useful speech. Warm stream retention remains the capture-startup mitigation. Logs: `/tmp/infercat-102-warm-v2.log`; fresh 1.2 s/5 s gateway-transcribed checks: `/tmp/infercat-102-real-v2.log`. The acoustic fixture's strongly attenuated Chrome results are not claimed as dictation quality proof.
+
+The earlier Safari table below predates this first-data addendum. The final Safari rerun could not be driven: CUA returned `cgWindowNotFound` twice, including after opening the loopback page; Safari settings were untouched. The retained page now prints `firstData` and `recordingShown` for the founder's final-candidate check. This proof gap is explicit; neither the previous Safari run nor synthetic WebKit is represented as verifying the added first-data gate.
+
+## Real browser observations before the first-data addendum
+
+Native Chrome 152 and Firefox 153 were driven with their **real MacBook Pro Microphone**, not fake capture devices. A known synthetic spoken WAV was played through the Mac speakers; browser echo cancellation/input processing can attenuate it, so these are control/capture diagnostics, not natural-dictation quality scores. Local blobs were retained privately. Safari 26.5.2 WebDriver still returned the exact disabled-automation error, but the actual Safari window became available through CUA. Its normal localhost microphone prompt was allowed; no other Safari setting changed. CUA ran the real controls and retained seven Safari blobs.
+
+Real Firefox reproduced the ignored second mic tap at the 1-second boundary: baseline tap at1117 ms held `requesting`, native recorder=`recording`, mic disabled; it was still recording 2.2 s later and required a separate Stop at3434 ms. Candidate tap at1132 ms held the same pending/native state, mic enabled, and reached `done`. This is the context-resume arm in a real device run, in addition to the deterministic pending-permission fixture. Logs: `/tmp/infercat-102-firefox-early-before.log` and `-after.log`.
+
+The exact Safari ignored-Stop incident was **not reproduced** at the timed1–2 s/5 s attempts once permission was settled: those controls were already in `recording`, and Stop completed on baseline and candidate. This qualification remains; the Firefox reproduction does not identify every detail of the founder's Safari incident.
+
+| Safari run | Stream ready | Recorder start | First nonzero analyser | Stop tap | Result |
+|---|---:|---:|---:|---:|---|
+| Candidate cold, Stop button |83 ms|83 ms|1347 ms|1434 ms|done|
+| Candidate warm repeat |reused|8 ms|8 ms|1434 ms|done|
+| Candidate reopened device,5 s |51 ms|51 ms|1257 ms|5234 ms|done|
+| Candidate reopened device, second mic tap |29 ms|29 ms|160 ms|1434 ms|done|
+| Baseline cold, second mic tap |238 ms|238 ms|340 ms|1450 ms|done|
+| Baseline warm repeat |reused|33 ms|34 ms|1451 ms|done|
+| Baseline reopened device,5 s |147 ms|147 ms|198 ms|5233 ms|done|
+
+Milliseconds are from the actual pointer action, not nominal sleeps. Candidate was run before baseline; permission-only takes were discarded. Cold results vary with browser/device lifetime; warm analyser reads may contain a prefilled buffer and are not timestamps of a first new physical sample. Chrome's candidate early/5 s Stop actions occurred at 1346/5012 ms and Firefox's at 1349/5082 ms, all while recording and reaching the transcript result. The retained Safari clips were decoded and sent through the pinned CLI separately; Safari in-page authenticated gateway transcription was not exercised in the native-UI run.
+
+## Saved-blob split: capture versus model
+
+| Safari clip | Recorder elapsed | Decoded WAV | Leading quiet | Same-WAV CLI result |
+|---|---:|---:|---:|---|
+| Candidate cold early |1.351 s|0.380 s|230 ms|unrelated text from a short fragment|
+| Candidate warm early |1.426 s|1.4375 s|440 ms|the red bicycle|
+| Candidate reopened5 s |5.183 s|4.2525 s|250 ms|Pinnacle is beside the blue house. This is a test of the.|
+| Candidate second mic tap |1.405 s|1.330 s|270 ms|The red bicycle.|
+| Baseline cold early |1.212 s|1.2125 s|240 ms|The rent bicycle.|
+| Baseline warm early |1.418 s|1.4275 s|420 ms|the red bicycle|
+| Baseline reopened5 s |5.086 s|5.085 s|260 ms|The red bicycle is beside the blue house. This is a test of the inferno.|
+
+The candidate cold encoded duration is about 1 s shorter than the recorder clock; warm duration matches within codec padding. Together with the delayed first signal, this is capture/encoding-startup evidence **before inference**. Shorter leading quiet does not mean a better cold capture: it can mean the beginning was absent entirely. Leading quiet is consecutive 10 ms RMS windows below −60dBFS, not speech/word detection. The source fixture itself has 90 ms of initial quiet, and speaker/output/input latency also affects the acoustic recording.
+
+The exact Chrome5 s WAV (4.8 s,20 ms leading quiet) returned only“the”; the acoustic speaker path was strongly attenuated. Firefox5 s (5.0535 s,380 ms quiet) returned“The red bicycle is beside the blue house. This is a test of the infer.” No retained clip established an intact first word that only the model dropped, so no 300 ms silence was prepended. This does not assert that all possible model-start failures are ruled out. Audio playback/download remains available for a human auditory check; analysis claims here are from waveform, duration and same-WAV CLI evidence.
+
+Private evidence: `/tmp/infercat-102-blobs/analysis.json` maps all nine decoded/inferred blobs to their exact files; `safari-cold-first500.png`, `safari-warm-first500.png`, `chrome-first500.png` were inspected. Plots span 0–500 ms on a log amplitude scale; the short cold clip is zero-padded after its actual end for that fixed-width view. Raw audio is not committed. CLI: the same pinned audio.cpp CPU binary/checkpoint as100, `--task asr --family fun_asr_nano --backend cpu --language en --audio <decoded.wav> --text-out <result.txt>`. No live ASR runtime change was made for this check.
+
+## Reproduce and retain the Safari page
+
+From `web/`, run `node dev/mic-stop-server.mjs --prepare` once, then `node dev/mic-stop-server.mjs`. Preparation reads the immutable 243d92e controller and compiles it to `/tmp/infercat-102-baseline.js`; the serving job need not read the Desktop git database. Open `http://127.0.0.1:49102/dev/mic-stop.html`; add `?base` for that controller. One tap, speak, Stop; see timestamps/state, leading quiet, first 500 ms plot, playback and download. “Save local copy” writes a mode 0600 blob under `/tmp/infercat-102-blobs` through a same-origin, bounded loopback endpoint. Without an invite fragment there is no transcription upload; the optional fragment uses the local host and English hint for the spoken fixture. For Mandarin analysis, retain the blob and run the CLI with `--language zh`.
+
+`MIC_BASE=1 node dev/mic-stop-check.mjs` runs baseline Chrome/Firefox; omit the variable for the candidate. It expects the private founder invite file and known WAV under the documented `/tmp` paths; neither secret nor raw audio is printed/committed. The real-Safari run used the visible native controls, not synthetic WebKit or WebDriver.
+
+The requested page is kept available by temporary user job `ai.infercat.l2.harness.102`, with **no installed plist**, command `/opt/homebrew/bin/node /tmp/infercat-wt-102/web/dev/mic-stop-server.mjs`. Remove it with `launchctl remove ai.infercat.l2.harness.102` when founder verification ends. This is separate from 100's five founder demo jobs. Safari was left on the candidate page, idle with its microphone released. No product site deployment is performed by this ticket.

--- a/web/dev/mic-stop-check.mjs
+++ b/web/dev/mic-stop-check.mjs
@@ -1,0 +1,24 @@
+import { chromium,firefox } from 'playwright';
+import { Buffer } from 'node:buffer';
+import { readFileSync,writeFileSync,mkdirSync } from 'node:fs';
+const invite=JSON.parse(readFileSync('/tmp/infercat-founder-voice-invite.json','utf8')).invite;
+const out='/tmp/infercat-102-blobs';mkdirSync(out,{recursive:true,mode:0o700});
+for(const [name,type]of Object.entries({chrome:chromium,firefox})){
+ const browser=await type.launch(name==='chrome'?{channel:'chrome',headless:false,ignoreDefaultArgs:['--mute-audio'],args:['--use-fake-ui-for-media-stream']}:{headless:false,firefoxUserPrefs:{'media.navigator.permission.disabled':true}});
+ try{for(const delay of [1000,1200,5000]){
+  const page=await browser.newPage();await page.goto(`http://127.0.0.1:49102/dev/mic-stop.html${process.env.MIC_BASE?'?base':''}#${invite}`);
+  await page.locator('#fixture').setInputFiles('/tmp/infercat-078-input.wav');
+  await page.locator('#mic').click();await page.waitForTimeout(delay);
+  const before=await page.evaluate(()=>({state:window.recorder.state.kind,native:window.nativeRecorder?.state,disabled:document.querySelector('#mic').disabled}));
+  const box=await page.locator('#mic').boundingBox();await page.mouse.click(box.x+box.width/2,box.y+box.height/2);
+  await page.waitForTimeout(2200);const after=await page.evaluate(()=>window.recorder.state.kind);
+  console.log(JSON.stringify({name,delay,base:!!process.env.MIC_BASE,before,after}));
+  if(after==='recording'||after==='requesting')await page.locator('#stop').click();
+  try{await page.waitForFunction(()=>window.result && ('transcript' in window.result || 'transcriptionError' in window.result),null,{timeout:15000});
+   const result=await page.evaluate(()=>window.result);console.log(JSON.stringify(result));
+   const bytes=await page.evaluate(async()=>Array.from(new Uint8Array(await window.lastBlob.arrayBuffer())));
+   writeFileSync(`${out}/${name}-${process.env.MIC_BASE?'before':'after'}-${delay}.webm`,Buffer.from(bytes),{mode:0o600});
+  }catch{console.log(name,delay,'no completed transcript',await page.locator('#state').innerText());}
+  await page.locator('#release').click();await page.close();
+ }}finally{await browser.close();}
+}

--- a/web/dev/mic-stop-server.mjs
+++ b/web/dev/mic-stop-server.mjs
@@ -1,0 +1,28 @@
+// Local diagnostic page plus the immutable 101 controller, without copying it into the tree.
+import { readFileSync,writeFileSync,mkdirSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { Buffer } from 'node:buffer';
+import { resolve } from 'node:path';
+import { createServer, transformWithEsbuild } from 'vite';
+const root=resolve(import.meta.dirname,'..');
+const cache='/tmp/infercat-102-baseline.js';
+if(process.argv.includes('--prepare')) {
+ const source=execFileSync('git',['show','243d92e:web/src/voice.ts'],{cwd:resolve(root,'..'),encoding:'utf8'});
+ const before=await transformWithEsbuild(source.replace("from './api'", "from '/src/api.ts'"),'voice.before.ts',{loader:'ts'});
+ writeFileSync(cache,before.code);process.exit(0);
+}
+const before=readFileSync(cache,'utf8');
+const server=await createServer({root,server:{host:'127.0.0.1',port:49102,strictPort:true},plugins:[{
+ name:'mic-baseline',configureServer(server){
+ server.middlewares.use('/__save-blob',async(request,response)=>{
+  if(request.method!=='POST'||request.headers.origin!=='http://127.0.0.1:49102'){response.statusCode=403;response.end();return;}
+  const chunks=[];let size=0;
+  for await(const chunk of request){size+=chunk.length;if(size>25*1024*1024){response.statusCode=413;response.end();return;}chunks.push(chunk);}
+  const directory='/tmp/infercat-102-blobs';mkdirSync(directory,{recursive:true,mode:0o700});
+  const path=resolve(directory,`safari-${randomUUID()}.${request.headers['content-type']?.includes('mp4')?'m4a':'webm'}`);
+  writeFileSync(path,Buffer.concat(chunks),{mode:0o600});response.setHeader('Content-Type','application/json');response.end(JSON.stringify({savedPath:path}));
+ });
+ server.middlewares.use('/src/voice.before.ts',(_request,response)=>{response.setHeader('Content-Type','application/javascript');response.end(before);});}
+}]});
+await server.listen();server.printUrls();

--- a/web/dev/mic-stop.html
+++ b/web/dev/mic-stop.html
@@ -1,0 +1,59 @@
+<!doctype html><meta charset="utf-8"><title>102 — microphone Stop and saved-blob check</title>
+<style>body{font:16px system-ui;max-width:900px;margin:2rem auto;padding:0 1rem}button,input{margin:.4rem;padding:.6rem}pre{white-space:pre-wrap}svg{width:100%;height:120px;border:1px solid #888}</style>
+<h1>Local microphone check</h1><p>Tap Mic, speak immediately, then tap Mic or Stop. The recording stays in this page until you download it, save a private local copy, or transcribe it with your invite.</p>
+<label><input id="cold" type="checkbox">Release the stream after each take</label>
+<label>Optional spoken test fixture <input id="fixture" type="file" accept="audio/*"></label>
+<p><button id="mic">Mic</button><button id="stop">Stop</button><button id="cancel">Cancel</button><button id="release">Release microphone</button></p>
+<pre id="state">idle</pre><pre id="result"></pre><audio id="playback" controls></audio><button id="save" disabled>Save local copy</button><a id="download" hidden>Download this exact blob</a>
+<p>First 500 ms: peak envelope. Leading quiet uses 10 ms windows below −60 dBFS RMS; it is not word detection.</p><svg viewBox="0 0 500 100"><path id="wave" fill="none" stroke="black" /></svg>
+<script type="module">
+const base = new URLSearchParams(location.search).has('base');
+const {VoiceRecorder,transcribe} = await import(/* @vite-ignore */ base ? '/src/voice.before.ts' : '/src/voice.ts');
+const {DirectTransport} = await import('/src/transport/index.ts');
+const reference = new Audio(); let playbackURL, referenceURL, tapped = 0, markers = {}, actions = [];
+const mark = key => markers[key] ??= Math.round((performance.now()-tapped)*10)/10;
+const gum = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+Object.defineProperty(navigator,'mediaDevices',{configurable:true,value:{getUserMedia:async options=>{const stream=await gum(options);mark('streamReady');window.device=stream.getAudioTracks()[0].label;return stream;}}});
+const NativeRecorder=window.MediaRecorder;
+window.MediaRecorder=class extends NativeRecorder { constructor(...args){super(...args);window.nativeRecorder=this;this.addEventListener('dataavailable',e=>{if(e.data.size)mark('firstData');});} start(...args){mark('recorderStarted');super.start(...args);} };
+const read=AnalyserNode.prototype.getFloatTimeDomainData;
+AnalyserNode.prototype.getFloatTimeDomainData=function(samples){read.call(this,samples);mark('firstRead');if(samples.some(n=>n!==0))mark('signal');};
+async function keep(clip,signal){
+ window.lastBlob=clip;document.querySelector('#save').disabled=false;
+ window.result={base,browser:navigator.userAgent,device:window.device,markers,actions,bytes:clip.size};
+ if(playbackURL)URL.revokeObjectURL(playbackURL);playbackURL=URL.createObjectURL(clip);
+ document.querySelector('#playback').src=playbackURL;const link=document.querySelector('#download');link.hidden=false;link.href=playbackURL;link.download=clip.type.includes('mp4')?'take.m4a':'take.webm';
+ try {
+  const audio=await new OfflineAudioContext(1,1,16000).decodeAudioData(await clip.arrayBuffer());
+  const samples=audio.getChannelData(0),step=Math.round(audio.sampleRate*.01);let leading=0;
+  for(let i=0;i<samples.length;i+=step){const slice=samples.subarray(i,i+step);const rms=Math.sqrt(slice.reduce((v,n)=>v+n*n,0)/slice.length);if(rms>=.001)break;leading+=slice.length;}
+  const points=[];for(let i=0;i<50;i++){const slice=samples.subarray(i*step,(i+1)*step);const peak=Math.min(1,Math.max(0,...slice.map(Math.abs)));points.push(`M${i*10+5} ${50-peak*45}v${peak*90}`);}
+  document.querySelector('#wave').setAttribute('d',points.join(' '));
+  Object.assign(window.result,{duration:audio.duration,leadingQuietMs:Math.round(leading/audio.sampleRate*1000)});
+ } catch(error) {window.result.analysisError=error.name;}
+ document.querySelector('#result').textContent=JSON.stringify(window.result,null,2);
+ const invite=location.hash.slice(1);if(!invite)return '';
+ try {
+  const text=await transcribe(new DirectTransport('http://127.0.0.1:19080'),invite.split('.').at(-1),clip,'en',signal);
+  window.result.transcript=text;return text;
+ } catch(error) {window.result.transcriptionError=error.message;throw error;}
+ finally {document.querySelector('#result').textContent=JSON.stringify(window.result,null,2);}
+}
+
+const recorder=new VoiceRecorder(keep,state=>{if(state.kind==='recording')mark('recordingShown');document.querySelector('#state').textContent=JSON.stringify(state,(key,value)=>key==='waveform'?undefined:value);document.querySelector('#mic').disabled=state.kind==='transcribing'||(base&&state.kind==='requesting');});
+window.recorder=recorder;
+function action(kind){actions.push({kind,at:Math.round(performance.now()-tapped),state:recorder.state.kind,native:window.nativeRecorder?.state,micDisabled:document.querySelector('#mic').disabled});}
+document.querySelector('#fixture').onchange=event=>{if(referenceURL)URL.revokeObjectURL(referenceURL);referenceURL=URL.createObjectURL(event.target.files[0]);reference.src=referenceURL;};
+document.querySelector('#mic').onpointerdown=()=>{
+ if(!['recording','requesting'].includes(recorder.state.kind)){tapped=performance.now();markers={};actions=[];window.result=null;document.querySelector('#save').disabled=true;if(referenceURL){reference.currentTime=0;void reference.play();}}
+ action('mic');
+ if(recorder.toggle)recorder.toggle();else if(recorder.state.kind==='recording')recorder.stop();else void recorder.start();
+};
+document.querySelector('#mic').onclick=event=>{if(event.detail===0)document.querySelector('#mic').onpointerdown();};
+document.querySelector('#save').onclick=async()=>{const response=await fetch('/__save-blob',{method:'POST',headers:{'Content-Type':window.lastBlob.type},body:window.lastBlob});Object.assign(window.result,await response.json());document.querySelector('#result').textContent=JSON.stringify(window.result,null,2);};
+document.querySelector('#stop').onclick=()=>{action('stop');recorder.stop();reference.pause();};
+document.querySelector('#cancel').onclick=()=>{action('cancel');recorder.cancel();reference.pause();};
+document.querySelector('#release').onclick=()=>recorder.release();
+document.addEventListener('visibilitychange',()=>{if(document.hidden)recorder.release();});window.addEventListener('pagehide',()=>recorder.release());
+window.setInterval(()=>{if(document.querySelector('#cold').checked&&['done','error'].includes(recorder.state.kind))recorder.release();},100);
+</script>

--- a/web/dev/voice-check.mjs
+++ b/web/dev/voice-check.mjs
@@ -25,7 +25,7 @@ async function connected(width, lang, extra = '&transcriptions&speech') {
     window.MediaRecorder = class {
       static isTypeSupported(type) { return type.includes('webm'); }
       state = 'inactive'; mimeType = 'audio/webm;codecs=opus';
-      start() { this.state = 'recording'; window.__takes++; }
+      start() { this.state = 'recording'; window.__takes++; window.__deliverAudio = () => this.ondataavailable?.({ data: new window.Blob(['test audio']) }); if (!window.__holdAudio) window.queueMicrotask(window.__deliverAudio); }
       stop() { this.state = 'inactive'; window.queueMicrotask(() => { this.ondataavailable?.({ data: new window.Blob(['test recording']) }); this.onstop?.(); }); }
     };
     window.AudioContext = class {
@@ -73,9 +73,29 @@ try {
       await page.waitForTimeout(30);
       check(await page.locator('.composer .spoken').count() === 0, 'late permission stays cancelled');
 
+      await page.evaluate(() => { window.__holdMic = true; }); await mic.click();
+      check(await mic.isEnabled(), 'pending microphone accepts a Stop tap');
+      await mic.click();
+      await page.evaluate(() => { window.__holdMic = false; window.__permitMic(); });
+      await page.waitForTimeout(30);
+      check(await page.locator('.composer .spoken').count() === 0, 'queued Stop cancels before any captured audio');
+      check((await posts(page, '/v1/audio/transcriptions')).length === 0, 'empty pending take never uploads');
+      await page.evaluate(() => { window.dispatchEvent(new window.Event('pagehide')); window.__holdMic = true; window.__holdAudio = true; });
+      await mic.click(); await page.waitForTimeout(1500);
+      check(await mic.getAttribute('aria-pressed') === 'false' && !await mic.evaluate(el => el.classList.contains('on')), 'permission prompt never presses the mic');
+      await page.evaluate(() => { window.__holdMic = false; window.__permitMic(); }); await page.waitForTimeout(30);
+      check(await page.locator('.waveform').count() === 0 && await mic.getAttribute('aria-pressed') === 'false', 'cold recorder waits for first data, with idle waveform');
+      await shot(page, `cold-data-wait-${tag}`);
+      await page.evaluate(() => { window.__holdAudio = false; window.__deliverAudio(); });
+      await page.waitForFunction(() => document.querySelector('.mic')?.getAttribute('aria-pressed') === 'true');
+      await mic.click(); await page.waitForFunction(() => document.querySelector('.mic')?.getAttribute('aria-pressed') === 'false');
+      await page.waitForTimeout(800);
+      check((await posts(page, '/v1/audio/transcriptions')).length === 1, 'one tap after a delayed permission grant stops and transcribes');
+      await field.fill(''); await page.evaluate(() => { window.__posts = []; });
+      const priorTakes = await page.evaluate(() => window.__takes);
       await mic.focus(); await mic.press('Space');
       await page.waitForFunction(() => document.querySelector('.mic')?.getAttribute('aria-pressed') === 'true');
-      check(await page.evaluate(() => window.__takes) === 1, 'keyboard activation starts exactly one take');
+      check(await page.evaluate(() => window.__takes) === priorTakes + 1, 'keyboard activation starts exactly one take');
       await page.locator('.composer .spoken button').click();
       const acquired = await page.evaluate(() => window.__micRequests);
       await page.getByRole('button', { name: lang === 'zh' ? '设置' : 'Settings', exact: true }).click();

--- a/web/src/ui/Chat.tsx
+++ b/web/src/ui/Chat.tsx
@@ -978,7 +978,7 @@ function Composer({
   }, [disabled, sendBlocked, streaming, hasVoice, recorder]);
   const toggleRecording = () => {
     if (disabled || sendBlocked || streaming || document.hidden) return;
-    if (recorder.state.kind === 'recording') recorder.stop(); else void recorder.start();
+    recorder.toggle();
   };
   const editText = (value: string) => { recorder.clear(); onText(value); };
   const sendText = () => { recorder.cancel(); onSend(text); };
@@ -1073,8 +1073,8 @@ function Composer({
             if (!streaming && reading.length === 0 && !disabled && !sendBlocked && (text.trim() !== '' || attachments.length > 0)) sendText();
           }}
         />
-        {voice && <button className={`attach mic ${recording.kind === 'recording' ? 'on' : ''}`} aria-pressed={recording.kind === 'recording'} aria-label={tr(recording.kind === 'recording' ? 'app_mic_stop' : 'app_mic')}
-          disabled={disabled || sendBlocked || streaming || recording.kind === 'transcribing' || recording.kind === 'requesting'}
+        {voice && <button className={`attach mic ${recording.kind === 'recording' ? 'on' : ''}`} aria-pressed={recording.kind === 'recording'} aria-label={tr(recording.kind === 'recording' || recording.kind === 'requesting' ? 'app_mic_stop' : 'app_mic')}
+          disabled={disabled || sendBlocked || streaming || recording.kind === 'transcribing'}
           onPointerDown={(event) => { if (event.button === 0) toggleRecording(); }}
           onPointerCancel={() => recorder.cancel()}
           onClick={(event) => { if (event.detail === 0) toggleRecording(); }}><svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="square" aria-hidden="true"><rect x="7" y="2" width="6" height="10" rx="3" /><path d="M4 9.5a6 6 0 0 0 12 0M10 15.5V18M7 18h6" /></svg></button>}

--- a/web/src/voice.test.ts
+++ b/web/src/voice.test.ts
@@ -5,6 +5,7 @@ import type { Transport } from './transport';
 
 class FakeRecorder {
   static instances: FakeRecorder[] = [];
+  static deliver = true;
   static isTypeSupported = (mime: string) => mime.includes('webm');
   state = 'inactive';
   mimeType: string;
@@ -12,7 +13,7 @@ class FakeRecorder {
   onstop: (() => void) | null = null;
   onerror: (() => void) | null = null;
   constructor(_stream: unknown, options?: { mimeType: string }) { this.mimeType = options?.mimeType ?? ''; FakeRecorder.instances.push(this); }
-  start() { this.state = 'recording'; }
+  start() { this.state = 'recording'; if (FakeRecorder.deliver) queueMicrotask(() => this.ondataavailable?.({ data: new Blob(['audio']) })); }
   stop() { this.state = 'inactive'; queueMicrotask(() => { this.ondataavailable?.({ data: new Blob(['clip']) }); this.onstop?.(); }); }
 }
 class FakeContext {
@@ -28,7 +29,7 @@ describe('voice recorder ownership', () => {
   const stream = { getTracks: () => [{ stop: stopTrack }] };
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'performance'] });
-    FakeRecorder.instances = []; FakeContext.level = .1;
+    FakeRecorder.instances = []; FakeRecorder.deliver = true; FakeContext.level = .1;
     FakeRecorder.isTypeSupported = (mime) => mime.includes('webm');
     vi.stubGlobal('requestAnimationFrame', (cb: () => void) => setTimeout(cb, 0));
     vi.stubGlobal('cancelAnimationFrame', (id: ReturnType<typeof setTimeout>) => clearTimeout(id));
@@ -100,6 +101,75 @@ describe('voice recorder ownership', () => {
     const pending = recorder.start(); recorder.release(); grant(stream); await pending;
     expect(FakeRecorder.instances).toHaveLength(0); expect(stopTrack).toHaveBeenCalledTimes(1);
     expect(recorder.state.kind).toBe('idle');
+  });
+  it.each(['stop', 'cancel', 'mic'] as const)('honours %s during a pending cold take', async (action) => {
+    let grant!: (value: unknown) => void;
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: vi.fn().mockImplementationOnce(() => new Promise((resolve) => { grant = resolve; })).mockResolvedValue(stream) } });
+    const upload = vi.fn(async () => 'short take');
+    const recorder = new VoiceRecorder(upload, () => {});
+    const pending = recorder.start(); expect(recorder.state.kind).toBe('requesting');
+    if (action === 'mic') recorder.toggle(); else recorder[action]();
+    grant(stream); await pending; await flush();
+    expect(FakeRecorder.instances.every((r) => r.state === 'inactive')).toBe(true);
+    expect(recorder.state.kind).toBe('idle'); expect(upload).not.toHaveBeenCalled();
+    // A Stop before capture yields no audio; the next intentional warm tap still works.
+    await recorder.start(); expect(recorder.state.kind).toBe('recording');
+    recorder.release();
+  });
+  it.each(['stop', 'cancel', 'mic'] as const)('preserves %s on a warm take', async (action) => {
+    const upload = vi.fn(async () => 'short take');
+    const recorder = new VoiceRecorder(upload, () => {});
+    await recorder.start(); recorder.cancel(); await flush();
+    await recorder.start(); await vi.advanceTimersByTimeAsync(100);
+    if (action === 'mic') recorder.toggle(); else recorder[action]();
+    await flush();
+    expect(FakeRecorder.instances.at(-1)?.state).toBe('inactive');
+    expect(recorder.state.kind).toBe(action === 'cancel' ? 'idle' : 'done');
+    expect(upload).toHaveBeenCalledTimes(action === 'cancel' ? 0 : 1);
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+    recorder.release();
+  });
+  it.each(['stop', 'cancel', 'mic'] as const)('honours %s while the monitoring context is resuming', async (action) => {
+    let resume!: () => void;
+    class ResumingContext extends FakeContext { resume = vi.fn(() => new Promise<void>((resolve) => { resume = resolve; })); }
+    vi.stubGlobal('AudioContext', ResumingContext);
+    const upload = vi.fn(async () => 'short take'); const recorder = new VoiceRecorder(upload, () => {});
+    const pending = recorder.start(); await flush(); await vi.advanceTimersByTimeAsync(50);
+    expect(recorder.state.kind).toBe('requesting'); expect(FakeRecorder.instances.at(-1)?.state).toBe('recording');
+    if (action === 'mic') recorder.toggle(); else recorder[action]();
+    await flush(); resume(); await pending;
+    expect(recorder.state.kind).toBe(action === 'cancel' ? 'idle' : 'done');
+    expect(upload).toHaveBeenCalledTimes(action === 'cancel' ? 0 : 1);
+    recorder.release();
+  });
+  it('does not upload an empty take', async () => {
+    const upload = vi.fn(); const recorder = new VoiceRecorder(upload, () => {});
+    FakeRecorder.deliver = false; await recorder.start(); FakeRecorder.instances.at(-1)!.ondataavailable = null;
+    recorder.stop(); await flush();
+    expect(recorder.state.kind).toBe('idle'); expect(upload).not.toHaveBeenCalled(); recorder.release();
+  });
+  it('waits for nonempty cold data, starts the counter then, and adds no warm wait', async () => {
+    FakeRecorder.deliver = false;
+    const recorder = new VoiceRecorder(vi.fn(async () => 'hello'), () => {});
+    await recorder.start(); await vi.advanceTimersByTimeAsync(700);
+    const native = FakeRecorder.instances.at(-1)!;
+    native.ondataavailable?.({ data: new Blob() });
+    expect(recorder.state.kind).toBe('requesting');
+    native.ondataavailable?.({ data: new Blob(['audio']) });
+    expect(recorder.state).toMatchObject({ kind: 'recording', seconds: 0 });
+    await vi.advanceTimersByTimeAsync(1000); recorder.stop(); await flush();
+    expect(recorder.state).toMatchObject({ kind: 'done', seconds: 1 });
+    await recorder.start(); expect(recorder.state).toMatchObject({ kind: 'recording', seconds: 0 });
+    recorder.release(); await recorder.start(); expect(recorder.state.kind).toBe('requesting'); recorder.release();
+  });
+  it('a multi-second permission prompt followed by one mic tap stops the granted take', async () => {
+    let grant!: (value: unknown) => void;
+    vi.stubGlobal('navigator', { mediaDevices: { getUserMedia: () => new Promise((resolve) => { grant = resolve; }) } });
+    const recorder = new VoiceRecorder(vi.fn(async () => 'hello'), () => {});
+    const pending = recorder.start(); await vi.advanceTimersByTimeAsync(5000);
+    expect(recorder.state.kind).toBe('requesting');
+    grant(stream); await pending; expect(recorder.state.kind).toBe('recording');
+    recorder.toggle(); await flush(); expect(recorder.state.kind).toBe('done'); recorder.release();
   });
   it('cancel never uploads and a delayed old stop cannot stop a new take', async () => {
     const upload = vi.fn(async () => 'hello');

--- a/web/src/voice.ts
+++ b/web/src/voice.ts
@@ -45,8 +45,10 @@ export class VoiceRecorder {
   private tick: ReturnType<typeof setInterval> | undefined;
   private cap: ReturnType<typeof setTimeout> | undefined;
   private frame: number | undefined;
-  private started = 0;
+  private started: number | null = null;
+  private streamDelivered = false;
   private stoppedSeconds: number | null = null;
+  private stopPending = false;
   constructor(private readonly upload: (clip: Blob, signal: AbortSignal) => Promise<string>, private readonly changed: (state: RecordingState) => void) {}
   private emit(state: RecordingState): void { this.state = state; this.changed(state); }
   async start(): Promise<void> {
@@ -70,7 +72,14 @@ export class VoiceRecorder {
       const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
       this.recorder = recorder;
       const chunks: Blob[] = [];
-      recorder.ondataavailable = (event) => { if (!controller.signal.aborted && event.data.size) chunks.push(event.data); };
+      let publish = () => {};
+      recorder.ondataavailable = (event) => {
+        if (controller.signal.aborted || !event.data.size) return;
+        chunks.push(event.data); this.streamDelivered = true;
+        if (this.started === null && recorder.state === 'recording') {
+          this.started = performance.now(); publish();
+        }
+      };
       recorder.onerror = () => {
         if (!controller.signal.aborted) { this.cancel(); this.emit({ kind: 'error', seconds: this.elapsed(), error: new Error('Microphone recording failed.') }); }
       };
@@ -79,6 +88,7 @@ export class VoiceRecorder {
         const seconds = this.stoppedSeconds ?? this.elapsed(); this.finishTake();
         const clip = new Blob(chunks, { type: recorder.mimeType || mimeType });
         chunks.length = 0;
+        if (!clip.size) { this.emit({ kind: 'idle' }); return; }
         this.emit({ kind: 'transcribing', seconds });
         void this.upload(clip, controller.signal).then((text) => {
           if (!controller.signal.aborted) this.emit({ kind: 'done', seconds, text });
@@ -86,7 +96,7 @@ export class VoiceRecorder {
           if (!controller.signal.aborted) this.emit(error instanceof Error && error.name === 'AbortError' ? { kind: 'idle' } : { kind: 'error', seconds, error });
         });
       };
-      this.started = performance.now(); this.stoppedSeconds = null;
+      this.started = this.streamDelivered ? performance.now() : null; this.stoppedSeconds = null;
       recorder.start(250);
       this.cap = setTimeout(() => this.stop(), RECORDING_LIMIT_SECONDS * 1000);
       if (!this.analyser) {
@@ -94,19 +104,22 @@ export class VoiceRecorder {
         context.createMediaStreamSource(stream).connect(this.analyser);
       }
       const analyser = this.analyser;
+      // A Stop before stream resolution cannot contain audio; honour it before a take escapes.
+      if (this.stopPending) { this.cancel(); return; }
       // Capture already owns the stream; keep the waiting line while audio wakes up.
       await resumed;
       if (controller.signal.aborted || recorder.state !== 'recording') return;
       const samples = new Float32Array(analyser.fftSize);
       const waveform: number[] = Array(60).fill(0);
       const sample = () => {
+        if (this.started === null) return;
         analyser.getFloatTimeDomainData(samples);
         const rms = Math.sqrt(samples.reduce((sum, n) => sum + n * n, 0) / samples.length);
         const level = Math.min(1, rms * 4); waveform.push(level); waveform.shift();
         this.emit({ kind: 'recording', seconds: this.elapsed(), level, waveform: [...waveform] });
       };
-      // Read immediately, then on the first paint; no empty interval before feedback.
-      sample();
+      // Cold capture stays waiting until bytes arrive; a proven warm stream has no extra wait.
+      publish = sample; sample();
       this.frame = requestAnimationFrame(() => {
         if (controller.signal.aborted || recorder.state !== 'recording') return;
         sample();
@@ -119,13 +132,19 @@ export class VoiceRecorder {
       this.emit(name === 'NotAllowedError' || name === 'SecurityError' ? { kind: 'blocked' } : name === 'NotFoundError' || name === 'NotSupportedError' ? { kind: 'missing' } : { kind: 'error', seconds: 0, error });
     }
   }
-  private elapsed(): number { return Math.min(RECORDING_LIMIT_SECONDS, Math.max(0, (performance.now() - this.started) / 1000)); }
+  private elapsed(): number { return Math.min(RECORDING_LIMIT_SECONDS, this.started === null ? 0 : Math.max(0, (performance.now() - this.started) / 1000)); }
+  toggle(): void {
+    if (this.state.kind === 'requesting' || this.state.kind === 'recording') this.stop();
+    else if (this.state.kind !== 'transcribing') void this.start();
+  }
   stop(): void {
     clearInterval(this.tick); clearTimeout(this.cap);
     if (this.frame !== undefined) cancelAnimationFrame(this.frame);
     if (this.recorder?.state === 'recording') { this.stoppedSeconds = this.elapsed(); this.recorder.stop(); this.finishTake(); }
+    else if (this.state.kind === 'requesting') this.stopPending = true;
   }
   cancel(): void {
+    this.stopPending = false;
     this.controller?.abort(); this.controller = null;
     if (this.recorder?.state === 'recording') this.recorder.stop();
     this.finishTake(); this.emit({ kind: 'idle' });
@@ -134,7 +153,7 @@ export class VoiceRecorder {
   /** Hide, unmount, or loss of access ends the permission-owned warm stream. */
   release(): void {
     this.cancel();
-    this.stream?.getTracks().forEach((track) => track.stop()); this.stream = null;
+    this.stream?.getTracks().forEach((track) => track.stop()); this.stream = null; this.streamDelivered = false;
     void this.context?.close().catch(() => {}); this.context = null; this.analyser = null;
   }
   private finishTake(): void {


### PR DESCRIPTION
A Stop during a cold microphone request was discarded: the composer disabled the mic and the recorder had no pending-Stop intent. The mic now accepts Stop throughout startup; a pre-capture Stop cancels once the stream arrives, and Stop during context resume ends the active take. Cold recording display and its counter wait for the first nonempty chunk; a proven warm stream adds no wait. Pressed styling is derived from recorder state.

Real Firefox reproduced the failure at 1117 ms (requesting/native recording, disabled mic, still recording afterward); the candidate honours the equivalent tap. Earlier native Safari runs completed Stop; saved blobs demonstrate cold capture startup loss and warm retention. The final first-data addendum was measured in Chrome/Firefox; Safari's window became unavailable to CUA, so its final-candidate check remains explicitly outstanding. The retained loopback page exposes the measurements for the founder.

Validation: make check OK; 403 web tests / 0 failed / 0 skipped; 32 voice unit tests; 229 UI assertions including delayed permission grant, unpressed pending mic, first-data waiting, and one-tap Stop. No new copy or ASR change. Measurements and reproduction are in web/dev/102-stop-measurements.md. Private raw audio is excluded.

Freeze: L2, size 1, base 243d92e; source +29/-10, tests/diagnostics +205/-4, docs +70/-0, total +304/-14 across eight files. No numeric LOC ceiling stated. Zero product concepts; one loopback diagnostic harness. No product deployment. Temporary harness job ai.infercat.l2.harness.102 stays available on port 49102; removal is documented.
