### PR TITLE
117: adapt resident Qwen speech for the Mandarin try-out

### DIFF
--- a/hack/tts-shim/README.md
+++ b/hack/tts-shim/README.md
@@ -1,0 +1,46 @@
+# Local Qwen speech proof adapter (117)
+
+The pinned audio.cpp Qwen route returns WAV even when a client requests MP3. Infercat's current voice player expects MP3. This Python standard-library adapter calls the resident native route, then encodes once with FFmpeg; it adds no ML package, framework, voice cloning or product route.
+
+Runtime: [audio.cpp fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416](https://github.com/0xShug0/audio.cpp/tree/fa5aaac9266a98c68f8a5c9fcd1ba6ff65875416), Apache-2.0. Build with Metal and only `qwen3_tts`:
+
+```sh
+cmake -S audio.cpp -B build/tts-metal -DCMAKE_BUILD_TYPE=Release \
+  -DENGINE_ENABLE_METAL=ON -DENGINE_ENABLE_OPENMP=OFF \
+  -DAUDIOCPP_DEPLOYMENT_BUILD=ON -DAUDIOCPP_MODEL_SET=custom -DAUDIOCPP_MODELS=qwen3_tts
+cmake --build build/tts-metal --target audiocpp_server -j 4
+```
+
+Checkpoint: [publisher's Qwen3-TTS 1.7B CustomVoice Q8_0](https://huggingface.co/audio-cpp/audio.cpp-gguf/tree/056144d2744697c9439bd32647279674dba0c964/Qwen3-TTS-12Hz-1.7B-CustomVoice-GGUF), Apache-2.0 for this model. File `qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf`, 2,817,044,064 bytes, SHA256 `3cfaac8e9f13554f6daea3c5e0c53fede71ef5500cbaae7445e5fc3a5bb12e72`. No weights or binaries are redistributed.
+
+Save the following as `runtime.json`, adjusting only the absolute model path:
+
+```json
+{
+  "host": "127.0.0.1", "port": 18087, "backend": "metal", "threads": 4,
+  "lazy_load": false, "idle_unload_ms": 0, "ui": false, "ui_management": false,
+  "log_request_body": false, "max_request_body_bytes": 16384, "busy_timeout_ms": 1,
+  "models": [{
+    "id": "Qwen3-TTS-12Hz-1.7B-CustomVoice-Q8_0", "family": "qwen3_tts",
+    "path": "/absolute/path/qwen3-tts-12hz-1.7b-customvoice-q8_0.gguf",
+    "task": "tts", "mode": "offline", "default_voice_preset": {"voice_id": "Vivian"},
+    "default_request_options": {"max_tokens": "2048"}
+  }]
+}
+```
+
+With Python 3.9+ and FFmpeg on PATH:
+
+```sh
+python3 hack/tts-shim/server.py --config runtime.json \
+  --runtime /absolute/path/build/tts-metal/bin/audiocpp_server --port 18079
+python3 hack/tts-shim/check.py http://127.0.0.1:18079
+```
+
+The adapter owns the runtime child and terminates it on exit; omit `--runtime` only when that configured server already runs. Both bind loopback. `/v1/models` checks native health. `/v1/audio/speech` accepts nonempty `input`, optional native built-in `voice`, and `response_format` of `mp3` (default) or `wav`; the single configured model is used. No language field means native Auto. Only these fields are forwarded, so reference-audio/cloning inputs are not exposed.
+
+Limits: 16 KiB JSON, no chunked request body, 10-second body timeout, 300-second native request timeout, 32 MiB native audio cap, 30-second encode timeout; one synthesis at a time, overlapping starts get429. The native configuration serializes model use and caps generated tokens. This is offline synthesis: first audio waits for the whole WAV plus encoding. Cancellation disconnects the client; a dispatched native inference may finish before the adapter releases its slot. No audio/text is logged or persisted by the adapter.
+
+Point the host's `--upstream-speech` at the adapter and `--upstream-speech-model` at `Qwen3-TTS-12Hz-1.7B-CustomVoice-Q8_0`; update a host model allowlist if set. Preserve the host data directory/invite. A model change requires the next serve. The app sends no model or voice field.
+
+Measured M5 Max /64 GiB: native 100-character Mandarin/English RTF 0.25–0.27, peak process RSS 6.28 GiB. With MP3 adapter, first audio6.235/1.919 s for24.048/7.176 s outputs. Real local gateway→Chrome Mandarin playback started5.865 s after the gesture and ended cleanly. These are observations on one Mac, not streaming or general performance claims; native and adapter trials use different sampling seeds. Full passages, raw timings, founder verdict and six-job cleanup are in private `infercat-pm/docs/spikes/117-tts.md`. The 1.7B met real time, so 0.6B was not tested.

--- a/hack/tts-shim/check.py
+++ b/hack/tts-shim/check.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Live checks against the isolated adapter and real runtime; synthetic text only."""
+import concurrent.futures, json, os, pathlib, subprocess, sys, tempfile, time, urllib.error, urllib.request
+base = sys.argv[1] if len(sys.argv) > 1 else 'http://127.0.0.1:18088'
+passed = 0
+
+def request(path, data=None):
+    req = urllib.request.Request(base + path, data=data, headers={'Content-Type': 'application/json'})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r: return r.status, r.headers.get('Content-Type'), r.read()
+    except urllib.error.HTTPError as r: return r.code, r.headers.get('Content-Type'), r.read()
+def check(ok):
+    global passed
+    assert ok
+    passed += 1
+status, kind, body = request('/v1/models')
+check(status == 200 and '1.7B' in json.loads(body)['data'][0]['id'])
+for data, expected in [(b'{',400),(b'{"input":""}',400),(json.dumps({'input':'hello','response_format':'pcm'}).encode(),400),(b'x'*16385,413)]:
+    check(request('/v1/audio/speech',data)[0] == expected)
+for fmt in ['wav','mp3']:
+    status, kind, audio = request('/v1/audio/speech',json.dumps({'input':'你好，欢迎使用语音。','response_format':fmt}).encode())
+    check(status == 200 and kind == ('audio/wav' if fmt == 'wav' else 'audio/mpeg'))
+    decoded = subprocess.run(['ffmpeg','-v','error','-i','pipe:0','-f','null','-'],input=audio,capture_output=True)
+    check(decoded.returncode == 0 and len(audio) > 100)
+with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+    first = pool.submit(request,'/v1/audio/speech',json.dumps({'input':'今天我们测试这台电脑上的语音合成。请仔细听每个词的发音，以及句子之间自然的停顿。'}).encode())
+    time.sleep(.15)
+    check(request('/v1/audio/speech',b'{"input":"second"}')[0] == 429)
+    check(first.result()[0] == 200)
+with tempfile.TemporaryDirectory() as directory:
+    root = pathlib.Path(directory); pid_file = root / 'child.pid'; child = root / 'runtime'
+    child.write_text('#!' + sys.executable + '\nimport os,time\nopen(' + repr(str(pid_file)) + ',"w").write(str(os.getpid()))\ntime.sleep(60)\n')
+    child.chmod(0o700)
+    config = root / 'runtime.json'; config.write_text(json.dumps({'host':'127.0.0.1','port':1,'models':[{'id':'test'}]}))
+    owned = subprocess.Popen([sys.executable,str(pathlib.Path(__file__).with_name('server.py')),'--config',str(config),'--runtime',str(child),'--port','0'])
+    try:
+        for _ in range(100):
+            if pid_file.exists(): break
+            time.sleep(.02)
+        pid = int(pid_file.read_text()); owned.terminate(); owned.wait(timeout=10)
+        try: os.kill(pid,0); alive = True
+        except ProcessLookupError: alive = False
+        check(not alive and owned.returncode == 0)
+    finally:
+        if owned.poll() is None: owned.terminate(); owned.wait(timeout=10)
+print(f'TTS adapter: {passed} passed / 0 failed / 0 skipped')

--- a/hack/tts-shim/server.py
+++ b/hack/tts-shim/server.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Loopback Qwen speech proof: resident audio.cpp WAV -> requested MP3. No ML packages."""
+import argparse, json, signal, subprocess, threading, urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--config', required=True, help='audio.cpp config (one model, loopback)')
+parser.add_argument('--runtime', help='optional owned audiocpp_server executable')
+parser.add_argument('--port', type=int, default=18088)
+args = parser.parse_args()
+with open(args.config) as f:
+    config = json.load(f)
+assert config['host'] == '127.0.0.1' and len(config['models']) == 1
+model = config['models'][0]['id']
+upstream = 'http://127.0.0.1:' + str(config['port'])
+busy = threading.Lock()
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *unused): pass
+    def send(self, status, body, kind='application/json'):
+        self.send_response(status)
+        self.send_header('Content-Type', kind)
+        self.send_header('Content-Length', str(len(body)))
+        self.send_header('Connection', 'close')
+        self.end_headers()
+        self.close_connection = True
+        self.wfile.write(body)
+    def fail(self, status, message):
+        self.send(status, json.dumps({'error': {'message': message}}).encode())
+    def do_GET(self):
+        if self.path != '/v1/models': return self.fail(404, 'Not found')
+        try:
+            with urllib.request.urlopen(upstream + '/v1/models', timeout=3) as r: r.read(65536)
+            self.send(200, json.dumps({'object': 'list', 'data': [{'id': model, 'object': 'model'}]}).encode())
+        except Exception: self.fail(503, 'Speech runtime is unavailable')
+    def do_POST(self):
+        if self.path != '/v1/audio/speech': return self.fail(404, 'Not found')
+        if not busy.acquire(blocking=False): return self.fail(429, 'Speech runtime is busy')
+        try:
+            self.connection.settimeout(10)
+            n = int(self.headers.get('Content-Length', '0'))
+            if self.headers.get('Transfer-Encoding') or not 0 < n <= 16384:
+                return self.fail(413, 'Use a JSON body of at most 16 KiB')
+            data = json.loads(self.rfile.read(n))
+            if not isinstance(data, dict) or not isinstance(data.get('input'), str) or not data['input'].strip():
+                return self.fail(400, 'input must be nonempty text')
+            fmt = data.get('response_format', 'mp3')
+            if fmt not in ('mp3', 'wav'): return self.fail(400, 'Supported formats: mp3, wav')
+            payload = {'model': model, 'input': data['input'], 'response_format': 'wav'}
+            if 'voice' in data: payload['voice'] = data['voice']
+            body = json.dumps(payload).encode()
+            request = urllib.request.Request(upstream + '/v1/audio/speech', data=body, headers={'Content-Type': 'application/json'})
+            with urllib.request.urlopen(request, timeout=300) as response: audio = response.read(32 * 1024 * 1024 + 1)
+            if len(audio) > 32 * 1024 * 1024: return self.fail(502, 'Speech response exceeds 32 MiB')
+            if fmt == 'mp3':
+                audio = subprocess.run(['ffmpeg', '-v', 'error', '-i', 'pipe:0', '-f', 'mp3', '-codec:a', 'libmp3lame', '-b:a', '96k', 'pipe:1'], input=audio, capture_output=True, timeout=30, check=True).stdout
+            self.send(200, audio, 'audio/mpeg' if fmt == 'mp3' else 'audio/wav')
+        except (ValueError, UnicodeError): self.fail(400, 'Invalid JSON request')
+        except Exception: self.fail(502, 'Speech generation failed')
+        finally: busy.release()
+
+def stop(*unused): raise KeyboardInterrupt
+signal.signal(signal.SIGTERM, stop)
+child = subprocess.Popen([args.runtime, '--config', args.config]) if args.runtime else None
+try:
+    with ThreadingHTTPServer(('127.0.0.1', args.port), Handler) as server: server.serve_forever()
+except KeyboardInterrupt: pass
+finally:
+    if child:
+        child.terminate()
+        try: child.wait(timeout=5)
+        except subprocess.TimeoutExpired: child.kill(); child.wait()


### PR DESCRIPTION
The standard audio.cpp Qwen3-TTS route returns WAV even when the client asks for MP3; the current Infercat player expects MP3. This loopback Python stdlib adapter calls the resident native runtime and performs one FFmpeg encode, preserving the existing app contract without product changes or ML dependencies. It owns the optional runtime child, bounds input/output/time, and admits one synthesis at a time.

Qwen3-TTS 1.7B CustomVoice Q8_0 on this M5 Max holds real time (RTF 0.25–0.27), so the 0.6B fallback was not needed. The complete MP3 path produced 24.048 seconds of Mandarin audio from 100 characters in 6.235 seconds. A real request through the founder's unchanged invite began Chrome playback in 5.865 seconds and ended cleanly. This is an offline quality trial, not a streaming or speed upgrade over Kokoro; the private report contains the matched comparison and licence/footprint details.

Validation: 12 live checks passed / 0 failed / 0 skipped, including MP3/WAV decode, refusal cases, serialization and owned-child shutdown; two Python syntax checks; four native measurements, two adapter measurements, four Kokoro comparisons, and final real gateway/player proof. No full product gate rerun for this isolated hack-only tool. Checkpoint and runtime pins are in the README. No weights/binaries or private audio are committed.

Live operation was explicitly dispatched: the same founder invite now has Qwen speech; vision and ASR are unchanged. The existing kokoro launch-job label now owns the adapter and Qwen child. All six retained jobs remain; no seventh job. No launch-host or site deployment touched.

L2 / 117 / size1; base6cdea14c11654731699af807bcdf51a1cf95ea7a. Source +72, tests +46, docs +46; total +164/-0 across three files. One proof-tool concept, zero product concepts; no numeric LOC ceiling stated.
