### PR TITLE
144a: Add durable image jobs and bounded per-key outputs

### DIFF
--- a/cmd/infercat/audio_test.go
+++ b/cmd/infercat/audio_test.go
@@ -41,8 +41,13 @@ func TestAudioFlagsReloadAndStatus(t *testing.T) {
 	plat := testPlatform(fakeAddr, nil)
 	plat.startTunnel = func(context.Context, tunnelOptions) (tunnelServer, error) { return fakeTunnel{}, nil }
 	var audio upstream.AudioEngine
+	var images upstream.ImageEngine
 	plat.newGateway = func(o gatewayOptions, _ upstream.Upstream, _ keys.Store, _ usage.Recorder, _ func(string, ...any)) (gatewayServer, error) {
 		audio = o.Transcribe
+		images = o.Images
+		if images == nil || o.ImageModel != "image-model" {
+			t.Error("image config did not reach gateway")
+		}
 		if o.SpeechVoices["zh"] != "zf_xiaoxiao" || o.Speech == nil || o.MaxTranscriptionSeconds != 45 || o.TranscribeModel != "asr-model" || o.SpeechModel != "tts-model" {
 			t.Error("audio config did not reach gateway")
 		}
@@ -53,7 +58,7 @@ func TestAudioFlagsReloadAndStatus(t *testing.T) {
 	var out, errw lockedBuffer
 	done := make(chan int, 1)
 	go func() {
-		done <- run(ctx, []string{"serve", "--console", "off", "--data-dir", dir, "--upstream", engine.URL, "--upstream-transcribe", engine.URL, "--upstream-transcribe-key", "asr-key", "--upstream-speech", engine.URL, "--upstream-speech-key", "tts-key", "--max-transcription-seconds", "45", "--upstream-transcribe-model", "asr-model", "--upstream-speech-model", "tts-model", "--upstream-speech-voices", "zh=zf_xiaoxiao,default=af_heart"}, &out, &errw, nil, false, plat)
+		done <- run(ctx, []string{"serve", "--console", "off", "--data-dir", dir, "--upstream", engine.URL, "--upstream-transcribe", engine.URL, "--upstream-transcribe-key", "asr-key", "--upstream-speech", engine.URL, "--upstream-speech-key", "tts-key", "--max-transcription-seconds", "45", "--upstream-transcribe-model", "asr-model", "--upstream-speech-model", "tts-model", "--upstream-speech-voices", "zh=zf_xiaoxiao,default=af_heart", "--upstream-images", engine.URL, "--upstream-images-key", "image-key", "--upstream-images-model", "image-model"}, &out, &errw, nil, false, plat)
 	}()
 	select {
 	case <-gw.serving:
@@ -61,7 +66,7 @@ func TestAudioFlagsReloadAndStatus(t *testing.T) {
 		t.Fatalf("serve not ready: %s", errw.String())
 	}
 	cfg, err := loadConfig(dir)
-	if err != nil || cfg.UpstreamTranscribe != engine.URL || cfg.UpstreamSpeechKey != "tts-key" || cfg.MaxTranscriptionSeconds != 45 || cfg.UpstreamTranscribeModel != "asr-model" || cfg.UpstreamSpeechModel != "tts-model" || cfg.UpstreamSpeechVoices != "zh=zf_xiaoxiao,default=af_heart" {
+	if err != nil || cfg.UpstreamImages != engine.URL || cfg.UpstreamImagesKey != "image-key" || cfg.UpstreamImagesModel != "image-model" || cfg.UpstreamTranscribe != engine.URL || cfg.UpstreamSpeechKey != "tts-key" || cfg.MaxTranscriptionSeconds != 45 || cfg.UpstreamTranscribeModel != "asr-model" || cfg.UpstreamSpeechModel != "tts-model" || cfg.UpstreamSpeechVoices != "zh=zf_xiaoxiao,default=af_heart" {
 		t.Fatalf("remembered config %+v %v", cfg, err)
 	}
 	fi, _ := os.Stat(configPath(dir))
@@ -75,7 +80,7 @@ func TestAudioFlagsReloadAndStatus(t *testing.T) {
 	if err := admin.Reload(context.Background(), dir); err == nil {
 		t.Fatal("reload hid failed probes")
 	}
-	if audio.Info().Health.OK {
+	if audio.Info().Health.OK || images.Info().Health.OK {
 		t.Fatal("reload did not re-probe")
 	}
 	healthy.Store(true)
@@ -96,7 +101,7 @@ func TestAudioFlagsReloadAndStatus(t *testing.T) {
 func TestAudioKeyFlags(t *testing.T) {
 	dir := t.TempDir()
 	plat := testPlatform(fakeAddr, nil)
-	r := exec(t, plat, "keys", "add", "audio", "--daily-audio-seconds", "15", "--daily-speech-chars", "20", "--data-dir", dir)
+	r := exec(t, plat, "keys", "add", "audio", "--daily-audio-seconds", "15", "--daily-speech-chars", "20", "--daily-images", "3", "--max-queued-images", "2", "--data-dir", dir)
 	if r.code != 0 {
 		t.Fatalf("add %d %s", r.code, r.err)
 	}
@@ -105,11 +110,11 @@ func TestAudioKeyFlags(t *testing.T) {
 		t.Fatal(err)
 	}
 	k, err := s.Find(context.Background(), "audio")
-	if err != nil || k.Limits.DailyAudioSeconds != 15 || k.Limits.DailySpeechChars != 20 {
+	if err != nil || k.Limits.DailyAudioSeconds != 15 || k.Limits.DailySpeechChars != 20 || k.Limits.DailyImages != 3 || k.Limits.MaxQueuedImages != 2 {
 		t.Fatal("limits flags not stored")
 	}
 	r = exec(t, plat, "keys", "list", "--data-dir", dir)
-	if !strings.Contains(r.out, "AUDIO S/DAY") || !strings.Contains(r.out, "SPEECH CHARS/DAY") {
+	if !strings.Contains(r.out, "AUDIO S/DAY") || !strings.Contains(r.out, "SPEECH CHARS/DAY") || !strings.Contains(r.out, "IMAGES/DAY") || !strings.Contains(r.out, "IMAGE QUEUE") {
 		t.Fatal("keys list lacks audio limits")
 	}
 }

--- a/cmd/infercat/config.go
+++ b/cmd/infercat/config.go
@@ -20,6 +20,9 @@ const configName = "config.json"
 // Keys a newer build no longer knows (queue_timeout, request_timeout, max_body, retired by ticket
 // 010) are ignored on load and dropped on the next save.
 type config struct {
+	UpstreamImages          string `json:"upstream_images,omitempty"`
+	UpstreamImagesKey       string `json:"upstream_images_key,omitempty"`
+	UpstreamImagesModel     string `json:"upstream_images_model,omitempty"`
 	UpstreamSpeechVoices    string `json:"upstream_speech_voices,omitempty"`
 	UpstreamTranscribeModel string `json:"upstream_transcribe_model,omitempty"`
 	UpstreamSpeechModel     string `json:"upstream_speech_model,omitempty"`

--- a/cmd/infercat/console_test.go
+++ b/cmd/infercat/console_test.go
@@ -46,6 +46,11 @@ func TestConsoleKeyLifecycleAndCounts(t *testing.T) {
 		t.Fatal(minted)
 	}
 	id := minted["key_id"]
+	call("PATCH", "/keys/"+id, `{"daily_images":3,"max_queued_images":2}`, 200)
+	edited, _ := store.Find(ctx, id)
+	if edited.Limits.DailyImages != 3 || edited.Limits.MaxQueuedImages != 2 {
+		t.Fatal("image admin limits not applied")
+	}
 	secret := strings.TrimPrefix(minted["invite"], "ic1."+fakeAddr+".")
 	k, ok, err := store.Lookup(ctx, secret)
 	if err != nil || !ok || k.Limits.RPM != 42 {

--- a/cmd/infercat/keys.go
+++ b/cmd/infercat/keys.go
@@ -58,6 +58,8 @@ func limitFlags(fs *flag.FlagSet) func(base keys.Limits) keys.Limits {
 	maxCtx := fs.Int("max-context", 0, "context ceiling; 0 = the upstream's")
 	daily := fs.Int("daily-tokens", 0, "tokens per UTC day")
 	audio := fs.Int("daily-audio-seconds", 0, "transcription seconds per UTC day")
+	images := fs.Int("daily-images", 0, "images per UTC day (default 20)")
+	queuedImages := fs.Int("max-queued-images", 0, "queued images per key (default 8)")
 	speech := fs.Int("daily-speech-chars", 0, "speech Unicode code points per UTC day")
 	models := fs.String("models", "", "comma-separated model allowlist; empty = every model")
 	return func(l keys.Limits) keys.Limits {
@@ -75,6 +77,10 @@ func limitFlags(fs *flag.FlagSet) func(base keys.Limits) keys.Limits {
 				l.MaxContext = *maxCtx
 			case "daily-audio-seconds":
 				l.DailyAudioSeconds = *audio
+			case "daily-images":
+				l.DailyImages = *images
+			case "max-queued-images":
+				l.MaxQueuedImages = *queuedImages
 			case "daily-speech-chars":
 				l.DailySpeechChars = *speech
 			case "daily-tokens":
@@ -281,11 +287,11 @@ func (e *env) keysList(ctx context.Context, pre string, args []string) error {
 	}
 	seen := rep.LastSeen()
 	tw := tabwriter.NewWriter(e.out, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "ID\tNAME\tSTATUS\tRPM\tTPM\tDAILY\tAUDIO S/DAY\tSPEECH CHARS/DAY\tCREATED\tLAST SEEN")
+	fmt.Fprintln(tw, "ID\tNAME\tSTATUS\tRPM\tTPM\tDAILY\tAUDIO S/DAY\tSPEECH CHARS/DAY\tIMAGES/DAY\tIMAGE QUEUE\tCREATED\tLAST SEEN")
 	for _, k := range list {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			k.ID, k.Name, k.Status,
-			limitNum(k.Limits.RPM), limitNum(k.Limits.TPM), limitNum(k.Limits.DailyTokens), limitNum(k.Limits.DailyAudioSeconds), limitNum(k.Limits.DailySpeechChars),
+			limitNum(k.Limits.RPM), limitNum(k.Limits.TPM), limitNum(k.Limits.DailyTokens), limitNum(k.Limits.DailyAudioSeconds), limitNum(k.Limits.DailySpeechChars), limitNum(k.Limits.DailyImages), limitNum(k.Limits.MaxQueuedImages),
 			k.CreatedAt.Local().Format("2006-01-02"), ago(seen[k.ID]))
 	}
 	return tw.Flush()
@@ -476,6 +482,8 @@ Limit flags:
   --max-output-tokens N   clamp on max_tokens
   --max-context N         context ceiling (0 = the upstream's)
   --daily-tokens N        tokens per UTC day
+  --daily-images N       images per UTC day (default 20)
+  --max-queued-images N queued images per key (default 8)
   --daily-audio-seconds N transcription seconds per UTC day (default 3600)
   --daily-speech-chars N  speech code points per UTC day (default 200000)
   --models a,b            model allowlist (empty = every model); the host pin still applies

--- a/cmd/infercat/main.go
+++ b/cmd/infercat/main.go
@@ -67,6 +67,8 @@ type gatewayServer interface {
 }
 
 type gatewayOptions struct {
+	Images                       upstream.ImageEngine
+	ImageModel                   string
 	RemoteConsole                http.Handler
 	LiveHostName                 func() string
 	SpeechVoices                 map[string]string

--- a/cmd/infercat/serve.go
+++ b/cmd/infercat/serve.go
@@ -70,6 +70,9 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 	transcribeURL := fs.String("upstream-transcribe", cfg.UpstreamTranscribe, "explicit OpenAI transcription engine URL")
 	transcribeKey := fs.String("upstream-transcribe-key", cfg.UpstreamTranscribeKey, "transcription engine bearer")
 	speechURL := fs.String("upstream-speech", cfg.UpstreamSpeech, "explicit OpenAI speech engine URL")
+	imageURL := fs.String("upstream-images", cfg.UpstreamImages, "explicit OpenAI images engine URL")
+	imageKey := fs.String("upstream-images-key", cfg.UpstreamImagesKey, "images engine bearer")
+	imageModel := fs.String("upstream-images-model", cfg.UpstreamImagesModel, "host image model (otherwise first probed id)")
 	speechKey := fs.String("upstream-speech-key", cfg.UpstreamSpeechKey, "speech engine bearer")
 	maxAudio := fs.Int("max-transcription-seconds", intOr(cfg.MaxTranscriptionSeconds, 300), "maximum measured duration and unknown-duration reservation")
 	models := fs.String("models", cfg.Models, "comma-separated host model pin; all forgets it")
@@ -108,6 +111,10 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 	if err != nil {
 		return err
 	}
+	images, err := upstream.OpenImages(ctx, *imageURL, *imageKey)
+	if err != nil {
+		return err
+	}
 	consoleListener, err := admin.ListenConsole(*consoleAddr)
 	if err != nil {
 		return err
@@ -126,7 +133,8 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 		Upstream: *upURL, UpstreamKey: *upKey, Slots: *slots, Models: strings.Join(pinned, ","),
 		UpstreamTranscribeModel: *transcribeModel, UpstreamSpeechModel: *speechModel,
 		UpstreamSpeechVoices: *speechVoices,
-		UpstreamTranscribe:   *transcribeURL, UpstreamTranscribeKey: *transcribeKey, UpstreamSpeech: *speechURL, UpstreamSpeechKey: *speechKey, MaxTranscriptionSeconds: *maxAudio,
+		UpstreamImages:       *imageURL, UpstreamImagesKey: *imageKey, UpstreamImagesModel: *imageModel,
+		UpstreamTranscribe: *transcribeURL, UpstreamTranscribeKey: *transcribeKey, UpstreamSpeech: *speechURL, UpstreamSpeechKey: *speechKey, MaxTranscriptionSeconds: *maxAudio,
 		DevListen: *devListen, DERPMapURL: *derpMapURL,
 		Region: *region, Name: *name, WebURL: *webURLFlag, Console: *consoleAddr,
 	}); err != nil {
@@ -199,7 +207,8 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 		ModelsPinned:    pinned,
 		TranscribeModel: *transcribeModel, SpeechModel: *speechModel,
 		SpeechVoices: voices,
-		Transcribe:   transcribe, Speech: speech, MaxTranscriptionSeconds: float64(*maxAudio),
+		Images:       images, ImageModel: *imageModel,
+		Transcribe: transcribe, Speech: speech, MaxTranscriptionSeconds: float64(*maxAudio),
 		LogPrompts:  *logPrompts,
 		HostName:    hostName,
 		RelayRegion: func() string { return tun.Status().Region },
@@ -260,6 +269,9 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 		return st
 	}, func() error {
 		err := reload()
+		if images != nil {
+			err = errors.Join(err, images.Refresh(ctx))
+		}
 		for _, a := range []upstream.AudioEngine{transcribe, speech} {
 			if a != nil {
 				err = errors.Join(err, a.Refresh(ctx))
@@ -713,6 +725,9 @@ Flags:
   --upstream-speech-model ID default model (otherwise first probed id)
   --upstream-speech-voices MAP zh=VOICE,en=VOICE,default=VOICE; fills only an absent voice
   --upstream-transcribe-key TOKEN  transcription engine bearer
+  --upstream-images URL     explicit OpenAI images engine base URL
+  --upstream-images-key TOKEN images engine bearer
+  --upstream-images-model ID default image model
   --upstream-speech URL      explicit OpenAI speech engine base URL
   --upstream-speech-key TOKEN speech engine bearer
   --max-transcription-seconds N  measured upload ceiling / unknown reservation (default 300)

--- a/cmd/infercat/wire.go
+++ b/cmd/infercat/wire.go
@@ -43,6 +43,7 @@ func newPlatform() platform {
 		newGateway: func(o gatewayOptions, up upstream.Upstream, store keys.Store, rec usage.Recorder, logf func(string, ...any)) (gatewayServer, error) {
 			return gateway.New(gateway.Config{
 				RemoteConsole: o.RemoteConsole, LiveHostName: o.LiveHostName,
+				Images: o.Images, ImageModel: o.ImageModel,
 				ModelsPinned:    o.ModelsPinned,
 				SpeechVoices:    o.SpeechVoices,
 				TranscribeModel: o.TranscribeModel, SpeechModel: o.SpeechModel,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -395,7 +395,7 @@ usage history refuses audio rather than silently resetting its budget.
 `internal/run` separates the lifetime of a run from an HTTP request and from engine
 capacity. The host constructs the store and manager before exposing the gateway, runs startup
 and periodic expiry sweeps, and cancels the manager before draining listeners.
-Production registers no run kind. A trusted kind chooses a
+An explicitly configured image engine registers the image run kind. A trusted kind chooses a
 step, a tool/approval wait, or a terminal output; clients cannot submit executable
 code as a kind. Each engine step has a distinct attempt ID, persisted before
 execution, and an injected executor returns only after releasing and settling its
@@ -513,3 +513,51 @@ same stateless route.
 
 The current web client does not consume Responses; its versioned `/me` fixtures
 and strict shape guards remain unchanged. Older hosts have no Responses route.
+
+## Image runs (144a)
+
+An explicitly configured `--upstream-images URL` is probed through `/v1/models`
+(or `/health`); `--upstream-images-key` and `--upstream-images-model` follow the audio
+engine settings. An absent image model leaves the capability absent. `/me` adds
+optional `host.images {model, retention_days, queue_cap, queued}`, image limits
+`daily_images` (default 20) and `max_queued_images` (default 8), and
+`usage.today_images`. Zero/absent legacy fields take the defaults without rewriting
+stored keys. Queue caps and image daily limits can be edited through the key
+CLI/admin surface. Text/audio request-concurrency limits exclude image work;
+images retain the shared RPM ledger and their own resource reservation.
+
+`POST /v1/images/jobs` accepts `{prompts:[string], conversation?:string, client_request_id?:string}` and
+atomically admits one batch, returning 202 `{jobs:[run]}`. One prompt is interactive;
+several are planted. One image worker chooses interactive before planted and FIFO
+within each priority; running work is not preempted. `GET /v1/images/jobs` lists the
+key's image runs newest first, with `batch {id,index,count}` and queue `position`.
+`DELETE /v1/runs/{id}` cancels queued images immediately; for a running image it
+records cancellation but allows that image to finish Done, retaining its output.
+
+`GET /v1/images/outputs/{id}` returns only this key's PNG/JPEG bytes;
+`?download=1` adds an attachment disposition. `DELETE` discards the output.
+`POST /v1/images/generations` submits through the same worker and waits, returning
+`{created,data:[{b64_json}]}`. It accepts prompt, n (1–16, subject to the queue cap),
+1024x1024 size, optional configured model and b64_json format. A disconnected waiter
+does not cancel or replay its durable jobs. The engine must return bounded base64
+PNG/JPEG data; URL-only results are refused, never fetched. Native sd.cpp embedded
+control directives are refused in prompts so they cannot override the host's
+single-output dimensions/settings. Current decoded dimensions are bounded to 4096².
+
+The `images` meter reserves one image before dispatch. A definitive engine failure
+without output releases it; a valid output or ambiguous dispatched outcome charges
+one. Measured is one only for a valid image. Settlement uses the existing request
+owner and UTC accounting window; no crash-exact charging guarantee is added.
+The named refusal codes are `image_queue_full` and `image_budget_exhausted` (429).
+
+Each image run keeps `input {prompt, conversation?, client_request_id?}`. Both
+optional strings are bounded to 128 bytes. The client persists its opaque
+correlation id before submitting; an ambiguous response is reconciled by listing
+this key's runs, never by resubmitting. Correlation does not deduplicate: repeating
+an id creates a separate batch. Batch indexes are zero-based. `started` is the
+actual worker-acquisition timestamp; final elapsed is `updated - started`.
+The list and individual image-run GET/DELETE snapshots include `position` (zero
+when not queued). Each output is `{url,mime,w,h,bytes,expiresAt,gone?}`; metadata
+is sent without image bytes. One admission event names a batch's first sibling;
+clients refresh the whole image list on any run event and after reconnect, so
+all siblings, current positions and evictions are observed together.

--- a/docs/DATA-DIRECTORY.md
+++ b/docs/DATA-DIRECTORY.md
@@ -65,3 +65,11 @@ age is 24 hours; the sweep cancels abandoned waits. Startup recovery interrupts
 unfinished runs without replaying engine work; terminal snapshots remain readable
 until expiry. The host runs expiry sweeps at startup and once per minute.
 No CLI flags change these constants in this slice.
+
+Image runs keep PNG/JPEG bytes in `runs/<key-id>/images/<run-id>`, with private
+permissions, and only output metadata in the run snapshot. Each output is at most
+8 MiB. Images have a separate 256 MiB per-key budget: oldest outputs are evicted
+first, independently of the 64 MiB state ceiling. Outputs expire after seven days;
+Discard removes an output immediately. The run metadata remains with an output-gone
+marker until the run record expires. Startup sweeps remove orphaned artifacts;
+interrupted work is never automatically replayed.

--- a/internal/gateway/destination.go
+++ b/internal/gateway/destination.go
@@ -16,6 +16,7 @@ type Destination struct {
 	Up     interface{ Info() upstream.Info }
 	Text   upstream.Engine
 	Audio  upstream.AudioEngine
+	Images upstream.ImageEngine
 	Queue  slotQueue
 	model  string
 }
@@ -30,6 +31,9 @@ type Offers struct {
 func (d *Destination) Offers() Offers {
 	i := d.Up.Info()
 	o := Offers{Models: append([]string{}, i.Models...), Vision: i.Vision}
+	if d.Images != nil && d.model != "" && !slices.Contains(o.Models, d.model) {
+		o.Models = append(o.Models, d.model)
+	}
 	if d.Audio != nil {
 		o.Audio = []string{d.ID}
 		if d.model != "" && !slices.Contains(o.Models, d.model) {
@@ -78,6 +82,12 @@ func newRouter(text upstream.Engine, cfg Config) *Router {
 		d := &Destination{ID: audio.id, Kind: "engine", Origin: "local", Up: audio.up, Audio: audio.up, model: audio.model}
 		d.Queue.cap = func() int { return d.Up.Info().Slots }
 		r.routes[string(audio.route)] = d
+		r.destinations = append(r.destinations, d)
+	}
+	if cfg.Images != nil {
+		d := &Destination{ID: "images", Kind: "engine", Origin: "local", Up: cfg.Images, Images: cfg.Images, model: cfg.ImageModel}
+		d.Queue.cap = func() int { return 1 }
+		r.routes[string(imagesEndpoint)] = d
 		r.destinations = append(r.destinations, d)
 	}
 	return r

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -15,6 +15,8 @@ import (
 type Code string
 
 const (
+	CodeImageQueueFull        Code = "image_queue_full"
+	CodeImageBudgetExhausted  Code = "image_budget_exhausted"
 	CodeInvalidKey            Code = "invalid_key"
 	CodeKeyPaused             Code = "key_paused"
 	CodeKeyRevoked            Code = "key_revoked"
@@ -41,6 +43,8 @@ type codeRow struct {
 }
 
 var codeTable = map[Code]codeRow{
+	CodeImageQueueFull:        {http.StatusTooManyRequests, "rate_limit_error"},
+	CodeImageBudgetExhausted:  {http.StatusTooManyRequests, "rate_limit_error"},
 	CodeInvalidKey:            {http.StatusUnauthorized, "authentication_error"},
 	CodeKeyPaused:             {http.StatusForbidden, "permission_error"},
 	CodeKeyRevoked:            {http.StatusForbidden, "permission_error"},

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -28,6 +28,8 @@ import (
 // here: it is the engine's slot count, read live (DESIGN §1.5). Deadlines and the body cap are
 // constants (§1.6), each bounding one party's failure.
 type Config struct {
+	Images                       upstream.ImageEngine
+	ImageModel                   string
 	RemoteConsole                http.Handler
 	LiveHostName                 func() string
 	SpeechVoices                 map[string]string
@@ -263,11 +265,14 @@ func cors(h http.Handler) http.Handler {
 		hd.Set("Access-Control-Allow-Origin", "*")
 		hd.Set("Access-Control-Allow-Headers", "authorization, content-type")
 		hd.Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		if isRunRoute(r.URL.Path) {
+		if isRunRoute(r.URL.Path) || isImageRoute(r.URL.Path) {
 			hd.Set("Access-Control-Allow-Headers", "authorization, content-type, last-event-id")
 			hd.Set("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS")
 		}
 		hd.Set("Access-Control-Expose-Headers", "Retry-After")
+		if isImageRoute(r.URL.Path) {
+			hd.Set("Access-Control-Expose-Headers", "Retry-After, Content-Disposition")
+		}
 		if r.Method == http.MethodOptions {
 			hd.Set("Access-Control-Max-Age", "600")
 			w.WriteHeader(http.StatusNoContent)

--- a/internal/gateway/images.go
+++ b/internal/gateway/images.go
@@ -1,0 +1,394 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
+	"net/http"
+	"net/http/httptrace"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/infercat/infercat/internal/keys"
+	runstate "github.com/infercat/infercat/internal/run"
+	"github.com/infercat/infercat/internal/usage"
+)
+
+type imageRequest struct {
+	runID                       string
+	definitiveFailure, measured bool
+	charged                     float64
+}
+type imageOffer struct {
+	Model         string `json:"model"`
+	RetentionDays int    `json:"retention_days"`
+	QueueCap      int    `json:"queue_cap"`
+	Queued        int    `json:"queued"`
+}
+
+func (g *Gateway) imageOffer(key *keys.Key) *imageOffer {
+	d := g.router.route(string(imagesEndpoint))
+	if d == nil || !d.Up.Info().Health.OK {
+		return nil
+	}
+	model := d.model
+	if model == "" {
+		for _, v := range d.Up.Info().Models {
+			if v != "" {
+				model = v
+				break
+			}
+		}
+	}
+	if model == "" || !allowsModel(key, g.cfg.ModelsPinned, model) {
+		return nil
+	}
+	queued := 0
+	if g.runs != nil {
+		rows, _ := g.runs.Store.List(key.ID)
+		for _, r := range rows {
+			if r.Kind == "image" && r.State == runstate.Queued {
+				queued++
+			}
+		}
+	}
+	return &imageOffer{model, int(runstate.Retention / (24 * time.Hour)), keys.ImageDefaults(key.Limits).MaxQueuedImages, queued}
+}
+func isImageRoute(path string) bool {
+	return path == string(imagesEndpoint) || path == "/v1/images/jobs" || strings.HasPrefix(path, "/v1/images/outputs/")
+}
+
+type imageJob struct {
+	runstate.Run
+	Position int `json:"position"`
+}
+
+func (q *request) imageJobs() ([]imageJob, error) {
+	rows, e := q.g.runs.Store.List(q.key.ID)
+	if e != nil {
+		return nil, e
+	}
+	out := []imageJob{}
+	for _, v := range rows {
+		if v.Kind != "image" {
+			continue
+		}
+		r, e := q.g.runs.Store.Get(q.key.ID, v.ID)
+		if e != nil {
+			return nil, e
+		}
+		out = append(out, imageJob{r, q.g.runs.Position("image", r.ID)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Created.After(out[j].Created) })
+	return out, nil
+}
+func (q *request) imageRoute() {
+	if q.g.runs == nil {
+		q.fail(errf(CodeNotFound, 0, "images unavailable"))
+		return
+	}
+	q.w.Header().Set("Cache-Control", "no-store")
+	if strings.HasPrefix(q.r.URL.Path, "/v1/images/outputs/") {
+		id := strings.TrimPrefix(q.r.URL.Path, "/v1/images/outputs/")
+		if q.r.Method == http.MethodDelete {
+			if e := q.g.runs.Store.DiscardImage(q.key.ID, id); e != nil {
+				q.fail(runError(e))
+				return
+			}
+			q.writeJSON(map[string]bool{"discarded": true})
+			return
+		}
+		if q.r.Method != http.MethodGet {
+			q.fail(errf(CodeNotFound, 0, "output not found"))
+			return
+		}
+		raw, o, e := q.g.runs.Store.ReadImage(q.key.ID, id)
+		if e != nil {
+			q.fail(runError(e))
+			return
+		}
+		q.w.Header().Set("Content-Type", o.MIME)
+		q.w.Header().Set("X-Content-Type-Options", "nosniff")
+		if q.r.URL.Query().Get("download") == "1" {
+			ext := "png"
+			if o.MIME == "image/jpeg" {
+				ext = "jpg"
+			}
+			q.w.Header().Set("Content-Disposition", `attachment; filename="image.`+ext+`"`)
+		}
+		q.writeHeader(200)
+		q.armWrite()
+		_, _ = q.w.Write(raw)
+		return
+	}
+	if q.r.Method == http.MethodGet && q.r.URL.Path == "/v1/images/jobs" {
+		rows, e := q.imageJobs()
+		if e != nil {
+			q.fail(runError(e))
+			return
+		}
+		q.writeJSON(map[string]any{"jobs": rows})
+		return
+	}
+	if q.r.Method != http.MethodPost {
+		q.fail(errf(CodeNotFound, 0, "image route not found"))
+		return
+	}
+	offer := q.g.imageOffer(q.key)
+	if offer == nil {
+		q.fail(errf(CodeNotFound, 0, "this key has no image model"))
+		return
+	}
+	q.buffered = true
+	if q.g.bodies.Add(1) > runstate.MaxLiveHost {
+		q.fail(errf(CodeConcurrencyLimited, 1, "image submissions busy"))
+		return
+	}
+	var in struct {
+		ClientRequestID string   `json:"client_request_id"`
+		Prompts         []string `json:"prompts"`
+		Prompt          string   `json:"prompt"`
+		Conversation    string   `json:"conversation"`
+		N               int      `json:"n"`
+		Size            string   `json:"size"`
+		Model           string   `json:"model"`
+		ResponseFormat  string   `json:"response_format"`
+	}
+	dec := json.NewDecoder(http.MaxBytesReader(q.w, q.r.Body, runstate.MaxInput))
+	err := dec.Decode(&in)
+	if err != nil || dec.Decode(new(any)) != io.EOF {
+		q.fail(errf(CodeInvalidRequest, 0, "expected one bounded image request"))
+		return
+	}
+	_ = q.rc.SetReadDeadline(time.Time{})
+	syncCall := q.r.URL.Path == string(imagesEndpoint)
+	if syncCall {
+		if in.N == 0 {
+			in.N = 1
+		}
+		if in.N < 1 || in.N > runstate.MaxLiveKey || in.Prompt == "" || (in.Size != "" && in.Size != "1024x1024") || (in.ResponseFormat != "" && in.ResponseFormat != "b64_json") {
+			q.fail(errf(CodeInvalidRequest, 0, "images require a prompt, n=1..16, size 1024x1024 and b64_json"))
+			return
+		}
+		in.Prompts = make([]string, in.N)
+		for i := range in.Prompts {
+			in.Prompts[i] = in.Prompt
+		}
+	}
+	if in.Model != "" && in.Model != offer.Model {
+		q.fail(errf(CodeModelNotAllowed, 0, "image model is not shared"))
+		return
+	}
+	inputs := make([]json.RawMessage, len(in.Prompts))
+	for i, p := range in.Prompts {
+		inputs[i], _ = json.Marshal(runstate.ImageInput{Prompt: p, Conversation: in.Conversation, ClientRequestID: in.ClientRequestID})
+	}
+	priority := "interactive"
+	if len(inputs) > 1 {
+		priority = "planted"
+	}
+	rows, err := q.g.runs.SubmitBatch(q.key.ID, "image", priority, inputs)
+	if err != nil {
+		e := runError(err)
+		if errors.Is(err, runstate.ErrQueueLimit) {
+			e.Limit = offer.QueueCap
+			e.InFlight = offer.Queued
+		}
+		q.fail(e)
+		return
+	}
+	if !syncCall {
+		q.w.Header().Set("Content-Type", "application/json")
+		q.writeHeader(http.StatusAccepted)
+		_ = json.NewEncoder(q.w).Encode(map[string]any{"jobs": rows})
+		return
+	}
+	// Losing this HTTP waiter never cancels durable jobs and never causes replay.
+	data := []map[string]string{}
+	for _, r := range rows {
+		tick := time.NewTicker(100 * time.Millisecond)
+		for {
+			v, e := q.g.runs.Store.Get(q.key.ID, r.ID)
+			if e != nil {
+				tick.Stop()
+				q.fail(runError(e))
+				return
+			}
+			if v.State == runstate.Done {
+				raw, _, e := q.g.runs.Store.ReadImage(q.key.ID, r.ID)
+				tick.Stop()
+				if e != nil {
+					q.fail(runError(e))
+					return
+				}
+				data = append(data, map[string]string{"b64_json": base64.StdEncoding.EncodeToString(raw)})
+				break
+			}
+			if v.State == runstate.Failed || v.State == runstate.Cancelled {
+				tick.Stop()
+				code := CodeUpstreamError
+				if len(v.Attempts) > 0 && v.Attempts[len(v.Attempts)-1].Usage.Code == string(CodeImageBudgetExhausted) {
+					code = CodeImageBudgetExhausted
+				}
+				retry := 0
+				if code == CodeImageBudgetExhausted {
+					retry = secondsUntil(q.g.lim.now().UTC().Truncate(24*time.Hour).Add(24*time.Hour), q.g.lim.now())
+				}
+				q.fail(errf(code, retry, "image run %s ended: %s", v.ID, v.Reason))
+				return
+			}
+			select {
+			case <-q.r.Context().Done():
+				tick.Stop()
+				return
+			case <-q.g.runs.Done():
+				tick.Stop()
+				return
+			case <-tick.C:
+			}
+		}
+	}
+	q.writeJSON(map[string]any{"created": time.Now().Unix(), "data": data})
+}
+func (q *request) proxyImage(rid string, input json.RawMessage) {
+	q.kind = imagesEndpoint
+	q.image = &imageRequest{runID: rid}
+	q.ev.Kind = "image"
+	q.ev.Meters = []usage.Meter{{Class: "images", Unit: "images"}}
+	var in runstate.ImageInput
+	if runstate.ValidateImage(input) != nil || json.Unmarshal(input, &in) != nil {
+		q.fail(runError(runstate.ErrInvalid))
+		return
+	}
+	offer := q.g.imageOffer(q.key)
+	if offer == nil {
+		q.fail(errf(CodeUpstreamDown, 1, "image engine unavailable"))
+		return
+	}
+	if q.g.audioHistoryErr != nil {
+		q.fail(errf(CodeUpstreamDown, 1, "resource usage history unavailable"))
+		return
+	}
+	if e := q.resolveDestination(offer.Model); e != nil {
+		q.fail(e)
+		return
+	}
+	q.ev.Model = offer.Model
+	for _, stage := range []func() *gwError{q.admitImageKey, q.reserveImage, q.acquireSlot} {
+		if e := stage(); e != nil {
+			q.fail(e)
+			return
+		}
+	}
+	body, _ := json.Marshal(map[string]any{"model": offer.Model, "prompt": in.Prompt, "n": 1, "size": "1024x1024", "response_format": "b64_json"})
+	ctx, cancel := context.WithCancel(q.r.Context())
+	q.cancelUpstream = cancel
+	ctx = httptrace.WithClientTrace(ctx, &httptrace.ClientTrace{WroteHeaders: func() { q.dispatched.Store(true) }})
+	resp, err := q.destination.Images.ImageDo(ctx, body)
+	if err != nil {
+		q.outcome = outcomeEngineErr
+		q.fail(q.upstreamErr(err))
+		return
+	}
+	q.resp = resp
+	q.idle = time.AfterFunc(q.g.idleTimeout, cancel)
+	raw, err := io.ReadAll(io.LimitReader(idleReader{r: resp.Body, t: q.idle, d: q.g.idleTimeout}, 12<<20))
+	if err != nil || len(raw) >= 12<<20 {
+		q.outcome = outcomeCut
+		q.fail(errf(CodeUpstreamError, 0, "image response incomplete or too large"))
+		return
+	}
+	var result struct {
+		Data []struct {
+			Base64 string `json:"b64_json"`
+		} `json:"data"`
+	}
+	parseErr := json.Unmarshal(raw, &result)
+	q.image.definitiveFailure = resp.StatusCode/100 != 2 && len(result.Data) == 0
+	if parseErr != nil || len(result.Data) != 1 || result.Data[0].Base64 == "" {
+		q.outcome = outcomeEngineErr
+		detail := "expected one b64_json image; URL-only or malformed image results are unsupported"
+		if resp.StatusCode/100 != 2 {
+			detail = snippet(bytes.NewReader(raw))
+		}
+		q.fail(errf(CodeUpstreamError, 0, "image engine HTTP %d: %s", resp.StatusCode, detail))
+		return
+	}
+	decoded, err := base64.StdEncoding.DecodeString(result.Data[0].Base64)
+	if err != nil || len(decoded) > runstate.MaxImage {
+		q.outcome = outcomeEngineErr
+		q.fail(errf(CodeUpstreamError, 0, "image output exceeds 8 MiB or has invalid base64"))
+		return
+	}
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(decoded))
+	if err != nil || (format != "png" && format != "jpeg") || cfg.Width < 1 || cfg.Height < 1 || cfg.Width > 4096 || cfg.Height > 4096 {
+		q.outcome = outcomeEngineErr
+		q.fail(errf(CodeUpstreamError, 0, "engine output is not a bounded PNG or JPEG"))
+		return
+	}
+	if _, _, err = image.Decode(bytes.NewReader(decoded)); err != nil {
+		q.outcome = outcomeEngineErr
+		q.fail(errf(CodeUpstreamError, 0, "image output is incomplete"))
+		return
+	}
+	q.image.measured = true
+	meta, err := q.g.runs.Store.PutImage(q.key.ID, rid, decoded, "image/"+format, cfg.Width, cfg.Height)
+	if err != nil {
+		q.outcome = outcomeEngineErr
+		q.fail(runError(err))
+		return
+	}
+	q.outcome = outcomeServed
+	q.w.Header().Set("Content-Type", "application/json")
+	q.writeHeader(200)
+	_, _ = q.w.Write(meta)
+}
+func (q *request) reserveImage() *gwError {
+	st := q.g.lim.state(q.key.ID)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	now := q.g.lim.now()
+	st.prune(now)
+	m := st.meter("images")
+	limit := keys.ImageDefaults(q.key.Limits).DailyImages
+	if limit > 0 && m.today+m.reserved+1 > float64(limit) {
+		return errf(CodeImageBudgetExhausted, secondsUntil(st.day.Add(24*time.Hour), now), "daily image budget exhausted")
+	}
+	m.reserved++
+	q.adm.images = 1
+	return nil
+}
+func (q *request) settleImage() {
+	st := q.g.lim.state(q.key.ID)
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	now := q.g.lim.now()
+	st.prune(now)
+	m := st.meter("images")
+	m.reserved -= float64(q.adm.images)
+	if (q.dispatched.Load() || q.resp != nil) && !q.image.definitiveFailure {
+		q.image.charged = 1
+		m.today++
+	}
+	measured := 0.
+	if q.image.measured {
+		measured = 1
+	}
+	q.ev.Meters = []usage.Meter{{Class: "images", Unit: "images", Measured: measured, Charged: q.image.charged}}
+	q.ev.SettledAt = now
+}
+
+func (q *request) admitImageKey() *gwError {
+	a, e := q.g.lim.admitResource(q.key.ID, q.key.Limits, true)
+	if e == nil {
+		q.adm = a
+	}
+	return e
+}

--- a/internal/gateway/images_test.go
+++ b/internal/gateway/images_test.go
@@ -1,0 +1,258 @@
+package gateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"image"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/infercat/infercat/internal/keys"
+	runstate "github.com/infercat/infercat/internal/run"
+	"github.com/infercat/infercat/internal/upstream"
+)
+
+func tinyImage() string {
+	var b bytes.Buffer
+	_ = png.Encode(&b, image.NewRGBA(image.Rect(0, 0, 2, 2)))
+	return base64.StdEncoding.EncodeToString(b.Bytes())
+}
+func imagesHarness(t *testing.T, handler http.HandlerFunc) *harness {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer engine-key" {
+			t.Error("missing engine key")
+		}
+		if r.URL.Path == "/v1/models" {
+			_, _ = io.WriteString(w, `{"data":[{"id":"image-model"}]}`)
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	engine, e := upstream.OpenImages(context.Background(), server.URL, "engine-key")
+	if e != nil {
+		t.Fatal(e)
+	}
+	h := newHarness(t, Config{Images: engine, DataDir: t.TempDir()}, nil)
+	store, e := runstate.NewStore(h.gw.cfg.DataDir)
+	if e != nil {
+		t.Fatal(e)
+	}
+	m, e := runstate.New(store, h.gw.ExecuteStep, nil)
+	if e != nil {
+		t.Fatal(e)
+	}
+	h.gw.SetRuns(m)
+	t.Cleanup(m.Close)
+	return h
+}
+func submittedImages(t *testing.T, r resp) []runstate.Run {
+	t.Helper()
+	if r.status != 202 {
+		t.Fatalf("submit %d %s", r.status, r.body)
+	}
+	var v struct {
+		Jobs []runstate.Run `json:"jobs"`
+	}
+	if e := json.Unmarshal(r.body, &v); e != nil {
+		t.Fatal(e)
+	}
+	return v.Jobs
+}
+func waitImageJob(t *testing.T, h *harness, id string, want runstate.State) runstate.Run {
+	t.Helper()
+	var row runstate.Run
+	waitUntil(t, 3*time.Second, "image state", func() bool { row, _ = h.gw.runs.Store.Get(h.key.ID, id); return row.State == want })
+	return row
+}
+func TestImageRoutesBatchCancellationOutputsAndMeter(t *testing.T) {
+	entered := make(chan struct{}, 2)
+	release := make(chan struct{}, 2)
+	h := imagesHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		var in map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&in)
+		if in["n"] != float64(1) || in["model"] != "image-model" || in["response_format"] != "b64_json" {
+			t.Error(in)
+		}
+		entered <- struct{}{}
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"b64_json": tinyImage()}}})
+	})
+	h.setKey(func(k *keys.Key) { k.Limits.DailyImages = 2; k.Limits.MaxQueuedImages = 1 })
+	a := submittedImages(t, h.post("/v1/images/jobs", `{"prompts":["first"],"conversation":"chat"}`))[0]
+	<-entered
+	b := submittedImages(t, h.post("/v1/images/jobs", `{"prompts":["second"]}`))[0]
+	h.expectErr(h.post("/v1/images/jobs", `{"prompts":["third","fourth"]}`), CodeImageQueueFull)
+	if h.do("DELETE", "/v1/runs/"+a.ID, "bearer", "").status != 200 {
+		t.Fatal("cancel")
+	}
+	if r := waitImageJob(t, h, a.ID, runstate.Running); !r.CancelRequested {
+		t.Fatal("cancel not retained")
+	}
+	_ = h.do("DELETE", "/v1/runs/"+b.ID, "bearer", "")
+	waitImageJob(t, h, b.ID, runstate.Cancelled)
+	release <- struct{}{}
+	r := waitImageJob(t, h, a.ID, runstate.Done)
+	if len(r.Attempts) != 1 || r.Attempts[0].Usage.Meters[0].Charged != 1 {
+		t.Fatal(r)
+	}
+	if got := h.gw.Counters(h.key.ID); got.TodayImages != 1 || got.TodayTokens != 0 || got.InFlight != 0 {
+		t.Fatal(got)
+	}
+	var list struct {
+		Jobs []imageJob `json:"jobs"`
+	}
+	_ = json.Unmarshal(h.get("/v1/images/jobs").body, &list)
+	if len(list.Jobs) != 2 {
+		t.Fatal("batch cap mutated list")
+	}
+	out := h.get("/v1/images/outputs/" + a.ID + "?download=1")
+	if out.status != 200 || out.header.Get("Content-Type") != "image/png" || !strings.HasPrefix(out.header.Get("Content-Disposition"), "attachment;") {
+		t.Fatal(out)
+	}
+	var me map[string]any
+	_ = json.Unmarshal(h.get("/me").body, &me)
+	if me["host"].(map[string]any)["images"].(map[string]any)["model"] != "image-model" {
+		t.Fatal(me)
+	}
+	_ = h.do("DELETE", "/v1/images/outputs/"+a.ID, "bearer", "")
+	h.expectErr(h.get("/v1/images/outputs/"+a.ID), CodeNotFound)
+	h.setKey(func(k *keys.Key) { k.Limits.DailyImages = 1 })
+	h.expectErr(h.post("/v1/images/generations", `{"prompt":"budget refused"}`), CodeImageBudgetExhausted)
+}
+func TestImageSettlementFailureAndAmbiguity(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		status            int
+		body              string
+		charged, measured float64
+	}{
+		{"complete", 200, `{"data":[{"b64_json":"` + tinyImage() + `"}]}`, 1, 1},
+		{"definitive", 500, `{"error":{"message":"could not make it"}}`, 0, 0},
+		{"invalid", 200, `{"data":[{"b64_json":"bad"}]}`, 1, 0},
+		{"url-only", 200, `{"data":[{"url":"https://invalid.example/PRIVATE"}]}`, 1, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var calls atomic.Int32
+			h := imagesHarness(t, func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(tc.status)
+				_, _ = io.WriteString(w, tc.body)
+			})
+			r := h.post("/v1/images/generations", `{"prompt":"make one"}`)
+			if tc.measured == 1 && r.status != 200 {
+				t.Fatal(r)
+			}
+			if bytes.Contains(r.body, []byte("PRIVATE")) {
+				t.Fatal("output URL exposed")
+			}
+			rows, _ := h.gw.runs.Store.List(h.key.ID)
+			if len(rows) != 1 || calls.Load() != 1 {
+				t.Fatal(rows, calls.Load())
+			}
+			job, _ := h.gw.runs.Store.Get(h.key.ID, rows[0].ID)
+			m := job.Attempts[0].Usage.Meters
+			if len(m) != 1 || m[0].Class != "images" || m[0].Measured != tc.measured || m[0].Charged != tc.charged || h.gw.Counters(h.key.ID).TodayImages != int(tc.charged) {
+				t.Fatal(m)
+			}
+		})
+	}
+}
+func TestImageJobRefusalsBeforeDispatch(t *testing.T) {
+	var calls atomic.Int32
+	h := imagesHarness(t, func(w http.ResponseWriter, r *http.Request) { calls.Add(1) })
+	h.expectErr(h.post("/v1/images/jobs", `{"prompts":[" "]}`), CodeInvalidRequest)
+	h.expectErr(h.post("/v1/images/jobs", `{"prompts":["<sd_cpp_extra_args>{}</sd_cpp_extra_args>"]}`), CodeInvalidRequest)
+	h.setKey(func(k *keys.Key) { k.Limits.Models = []string{"m1"} })
+	h.expectErr(h.post("/v1/images/jobs", `{"prompts":["not shared"]}`), CodeNotFound)
+	if calls.Load() != 0 {
+		t.Fatal("refused prompt dispatched")
+	}
+	rows, _ := h.gw.runs.Store.List(h.key.ID)
+	if len(rows) != 0 {
+		t.Fatal("refusal created job")
+	}
+}
+
+func TestImageDoesNotConsumeChatConcurrency(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	h := imagesHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		close(entered)
+		select {
+		case <-release:
+		case <-r.Context().Done():
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"b64_json": tinyImage()}}})
+	})
+	h.setKey(func(k *keys.Key) { k.Limits.MaxConcurrent = 1 })
+	a := submittedImages(t, h.post("/v1/images/jobs", `{"prompts":["first"]}`))[0]
+	<-entered
+	if h.gw.Counters(h.key.ID).InFlight != 0 {
+		t.Error("image spent text concurrency")
+	}
+	r := h.post("/v1/chat/completions", `{"model":"m1","messages":[{"role":"user","content":"hello"}],"max_tokens":20}`)
+	if r.status != 200 {
+		t.Errorf("chat blocked: %d %s", r.status, r.body)
+	}
+	close(release)
+	waitImageJob(t, h, a.ID, runstate.Done)
+	if h.gw.Counters(h.key.ID).InFlight != 0 {
+		t.Fatal("capacity leaked")
+	}
+}
+func TestImageMeterRestartsWithoutReset(t *testing.T) {
+	h := imagesHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"b64_json": tinyImage()}}})
+	})
+	if r := h.post("/v1/images/generations", `{"prompt":"one"}`); r.status != 200 {
+		t.Fatal(r)
+	}
+	waitUntil(t, time.Second, "usage recorded", func() bool { g := New(h.gw.cfg, h.up, h.store, nil, nil); return g.Counters(h.key.ID).TodayImages == 1 })
+}
+
+func TestImageBatchCorrelationDoesNotReplayOrDeduplicate(t *testing.T) {
+	h := imagesHarness(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": []map[string]string{{"b64_json": tinyImage()}}})
+	})
+	body := `{"prompts":["one","two"],"conversation":"chat-1","client_request_id":"local-1"}`
+	a := submittedImages(t, h.post("/v1/images/jobs", body))
+	b := submittedImages(t, h.post("/v1/images/jobs", body))
+	if len(a) != 2 || len(b) != 2 || a[0].Batch.ID == b[0].Batch.ID {
+		t.Fatal("correlation became idempotency")
+	}
+	for _, r := range append(a, b...) {
+		var in runstate.ImageInput
+		_ = json.Unmarshal(r.Input, &in)
+		if in.ClientRequestID != "local-1" || in.Conversation != "chat-1" {
+			t.Fatal(in)
+		}
+		waitImageJob(t, h, r.ID, runstate.Done)
+	}
+	var list struct {
+		Jobs []imageJob `json:"jobs"`
+	}
+	_ = json.Unmarshal(h.get("/v1/images/jobs").body, &list)
+	if len(list.Jobs) != 4 {
+		t.Fatal(list)
+	}
+	for _, r := range list.Jobs {
+		if r.Position != 0 {
+			t.Fatal("terminal rank", r.Position)
+		}
+	}
+	h.expectErr(h.post("/v1/images/jobs", `{"prompts":["one"],"client_request_id":"`+strings.Repeat("x", 129)+`"}`), CodeInvalidRequest)
+}

--- a/internal/gateway/limits.go
+++ b/internal/gateway/limits.go
@@ -81,6 +81,8 @@ func (st *keyState) tokensReserved() int { return int(st.meter("tokens").reserve
 // wrote (by seq), and the tokens reserve later put on it. The request record holds it; nothing
 // else ends it.
 type admission struct {
+	images       int
+	detached     bool
 	audioSeconds float64
 	speechChars  int
 	key          string
@@ -186,6 +188,11 @@ func (l *limiter) touch(id string) {
 // promise 2): cheap and in memory, so a burst from one key is bounded by max_concurrent in buffered
 // bodies and in engine tokenize calls alike. The caller settles the admission exactly once.
 func (l *limiter) admit(id string, lim keys.Limits) (*admission, *gwError) {
+	return l.admitResource(id, lim, false)
+}
+
+// Images hold their own worker capacity, retaining the same RPM ledger and finish owner.
+func (l *limiter) admitResource(id string, lim keys.Limits, detached bool) (*admission, *gwError) {
 	st := l.state(id)
 	st.mu.Lock()
 	defer st.mu.Unlock()
@@ -193,7 +200,7 @@ func (l *limiter) admit(id string, lim keys.Limits) (*admission, *gwError) {
 	st.prune(now)
 	st.lastSeen = now
 
-	if lim.MaxConcurrent > 0 && st.inFlight >= lim.MaxConcurrent {
+	if !detached && lim.MaxConcurrent > 0 && st.inFlight >= lim.MaxConcurrent {
 		e := errf(CodeConcurrencyLimited, 1, "this key allows %d request(s) at a time; %d in flight", lim.MaxConcurrent, st.inFlight)
 		e.Limit, e.InFlight = lim.MaxConcurrent, st.inFlight
 		return nil, e
@@ -210,10 +217,12 @@ func (l *limiter) admit(id string, lim keys.Limits) (*admission, *gwError) {
 		}
 		return nil, errf(CodeRateLimited, secondsUntil(oldest.Add(window), now), "rate limit: %d requests per minute; %d used", lim.RPM, reqs)
 	}
-	st.inFlight++
+	if !detached {
+		st.inFlight++
+	}
 	st.seq++
 	st.log = append(st.log, logEntry{t: now, req: 1, seq: st.seq})
-	return &admission{key: id, seq: st.seq}, nil
+	return &admission{key: id, seq: st.seq, detached: detached}, nil
 }
 
 // minOutputTokens is the floor when max_tokens is shrunk to fit the context or a token budget.
@@ -310,7 +319,9 @@ func (l *limiter) settle(a *admission, counted bool, charged int) time.Time {
 	defer st.mu.Unlock()
 	now := l.now()
 	st.prune(now)
-	st.inFlight--
+	if !a.detached {
+		st.inFlight--
+	}
 	m := st.meter("tokens")
 	m.reserved -= float64(a.reserved)
 	if !counted {
@@ -340,7 +351,7 @@ func (l *limiter) counters(id string) usage.KeyCounters {
 	st.prune(l.now())
 	reqs, tokens := st.used()
 	text, audio, speech := st.meter("tokens"), st.meter("audio"), st.meter("speech")
-	return usage.KeyCounters{TodayAudioSeconds: audio.today + audio.reserved, TodaySpeechChars: int(speech.today + speech.reserved), InFlight: st.inFlight, RPMUsed: reqs, TPMUsed: tokens + int(text.reserved), TodayTokens: int(text.today + text.reserved), LastSeen: st.lastSeen}
+	return usage.KeyCounters{TodayImages: int(st.meter("images").today + st.meter("images").reserved), TodayAudioSeconds: audio.today + audio.reserved, TodaySpeechChars: int(speech.today + speech.reserved), InFlight: st.inFlight, RPMUsed: reqs, TPMUsed: tokens + int(text.reserved), TodayTokens: int(text.today + text.reserved), LastSeen: st.lastSeen}
 }
 
 func (l *limiter) allCounters() map[string]usage.KeyCounters {

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -349,13 +349,15 @@ type meResponse struct {
 	} `json:"key"`
 	Limits keys.Limits `json:"limits"`
 	Usage  struct {
+		TodayImages int `json:"today_images,omitempty"`
 		RPMUsed     int `json:"rpm_used"`
 		TPMUsed     int `json:"tpm_used"`
 		TodayTokens int `json:"today_tokens"`
 		InFlight    int `json:"in_flight"`
 	} `json:"usage"`
 	Host struct {
-		Name     string `json:"name"`
+		Images   *imageOffer `json:"images,omitempty"`
+		Name     string      `json:"name"`
 		Upstream struct {
 			Kind         upstream.Kind `json:"kind"`
 			Healthy      bool          `json:"healthy"`
@@ -377,8 +379,10 @@ type meResponse struct {
 func (q *request) me() {
 	var m meResponse
 	m.Key.ID, m.Key.Name, m.Key.Status = q.key.ID, q.key.Name, q.key.Status
-	m.Limits = q.key.Limits
+	m.Limits = keys.ImageDefaults(q.key.Limits)
+	m.Host.Images = q.g.imageOffer(q.key)
 	cnt := q.g.lim.counters(q.key.ID)
+	m.Usage.TodayImages = cnt.TodayImages
 	m.Usage.RPMUsed, m.Usage.TPMUsed, m.Usage.TodayTokens, m.Usage.InFlight = cnt.RPMUsed, cnt.TPMUsed, cnt.TodayTokens, cnt.InFlight
 	info := q.g.router.text.Up.Info()
 	m.Host.Name = q.g.cfg.HostName

--- a/internal/gateway/request.go
+++ b/internal/gateway/request.go
@@ -19,6 +19,7 @@ import (
 type endpoint string
 
 const (
+	imagesEndpoint     endpoint = "/v1/images/generations"
 	transcribeEndpoint endpoint = "/v1/audio/transcriptions"
 	speechEndpoint     endpoint = "/v1/audio/speech"
 	chatEndpoint       endpoint = "/v1/chat/completions"
@@ -33,7 +34,7 @@ const (
 // connect; counting it made the friend's first message read "2 of 20 used this minute" (ticket 014
 // ruling; measured on the real stack, 014 Log).
 func (e endpoint) countsAgainstRPM() bool {
-	return e == chatEndpoint || e == embeddingsEndpoint || e == transcribeEndpoint || e == speechEndpoint
+	return e == imagesEndpoint || e == chatEndpoint || e == embeddingsEndpoint || e == transcribeEndpoint || e == speechEndpoint
 }
 
 // outcome is how a request ended, set by the stage that ended it (DESIGN §1.4). finish reads it
@@ -74,6 +75,7 @@ type request struct {
 	destination *Destination
 	audio       *audioRequest
 	responses   *responsesAdapter
+	image       *imageRequest
 	g           *Gateway
 	w           http.ResponseWriter
 	r           *http.Request
@@ -123,6 +125,8 @@ func (q *request) serve() {
 	}
 	r := q.r
 	switch {
+	case isImageRoute(r.URL.Path):
+		q.imageRoute()
 	case isRunRoute(r.URL.Path):
 		q.runRoute()
 	case r.Method == http.MethodGet && r.URL.Path == "/me":
@@ -464,8 +468,11 @@ func (q *request) finish() {
 		if q.audio != nil {
 			q.settleAudio()
 		}
+		if q.image != nil {
+			q.settleImage()
+		}
 		settledAt := q.g.lim.settle(q.adm, counted, charged)
-		if q.audio == nil {
+		if q.audio == nil && q.image == nil {
 			q.ev.SettledAt = settledAt
 		} // the same UTC day for live charge and replay
 	}
@@ -475,6 +482,10 @@ func (q *request) finish() {
 		m := &q.ev.Meters[i]
 		m.Charged = 0
 		switch m.Class {
+		case "images":
+			if q.image != nil {
+				m.Charged = q.image.charged
+			}
 		case "tokens":
 			m.Charged = float64(charged)
 		case "audio", "speech":

--- a/internal/gateway/runs.go
+++ b/internal/gateway/runs.go
@@ -15,14 +15,30 @@ import (
 )
 
 // SetRuns is startup wiring only, before any gateway listener is exposed.
-func (g *Gateway) SetRuns(m *runstate.Manager) { g.runs = m }
+func (g *Gateway) SetRuns(m *runstate.Manager) {
+	g.runs = m
+	if g.cfg.Images != nil {
+		m.Register("image", runstate.ImageKind, runstate.Policy{Serial: true, DeferredCancel: true, Validate: runstate.ValidateImage, QueueLimit: func(key string) (int, error) {
+			all, e := g.store.List(context.Background())
+			if e != nil {
+				return 0, e
+			}
+			for _, k := range all {
+				if k.ID == key {
+					return keys.ImageDefaults(k.Limits).MaxQueuedImages, nil
+				}
+			}
+			return 0, runstate.ErrNotFound
+		}})
+	}
+}
 
 // ExecuteStep reuses the request owner; finish settles once before the result is observed.
 func (g *Gateway) ExecuteStep(ctx context.Context, keyID string, step runstate.Step, acquired func() error) (result runstate.StepResult, err error) {
 	if len(step.Input) > runstate.MaxInput || !json.Valid(step.Input) {
 		return result, runstate.ErrInvalid
 	}
-	if step.Route != string(chatEndpoint) && step.Route != string(embeddingsEndpoint) {
+	if step.Route != string(chatEndpoint) && step.Route != string(embeddingsEndpoint) && step.Route != string(imagesEndpoint) {
 		return result, runstate.ErrInvalid
 	}
 	sink := &runSink{ctx: ctx, header: make(http.Header)}
@@ -41,7 +57,7 @@ func (g *Gateway) ExecuteStep(ctx context.Context, keyID string, step runstate.S
 			err = sink.err
 		}
 		if err == nil && q.outcome != outcomeServed {
-			err = errors.New("run step ended: " + q.ev.Code)
+			err = errors.New("run step ended: " + q.ev.Code + ": " + sink.String())
 		}
 		if err == nil {
 			result.Output = append(json.RawMessage(nil), sink.Bytes()...)
@@ -80,7 +96,11 @@ func (g *Gateway) ExecuteStep(ctx context.Context, keyID string, step runstate.S
 		q.fail(errf(code, 0, "key is not active"))
 		return result, runstate.ErrInvalid
 	}
-	q.proxy(endpoint(step.Route))
+	if step.Route == string(imagesEndpoint) {
+		q.proxyImage(step.RunID, step.Input)
+	} else {
+		q.proxy(endpoint(step.Route))
+	}
 	return result, nil
 }
 
@@ -109,6 +129,8 @@ func (s *runSink) Write(p []byte) (int, error) {
 }
 func runError(err error) *gwError {
 	switch {
+	case errors.Is(err, runstate.ErrQueueLimit):
+		return errf(CodeImageQueueFull, 1, "image queue is full")
 	case errors.Is(err, runstate.ErrNotFound):
 		return errf(CodeNotFound, 0, "run not found")
 	case errors.Is(err, runstate.ErrLimit):
@@ -186,6 +208,9 @@ func (q *request) runRoute() {
 	if err != nil {
 		q.fail(runError(err))
 		return
+	}
+	if r, ok := value.(runstate.Run); ok && r.Kind == "image" {
+		value = imageJob{r, q.g.runs.Position("image", r.ID)}
 	}
 	q.w.Header().Set("Content-Type", "application/json")
 	q.writeHeader(status)

--- a/internal/keys/audio_test.go
+++ b/internal/keys/audio_test.go
@@ -46,3 +46,14 @@ func TestLegacyAudioDefaultsAreReadOnly(t *testing.T) {
 		t.Fatal("read rewrote keys")
 	}
 }
+
+func TestLegacyImageDefaults(t *testing.T) {
+	l := ImageDefaults(Limits{})
+	if l.DailyImages != 20 || l.MaxQueuedImages != 8 {
+		t.Fatal(l)
+	}
+	l = ImageDefaults(Limits{DailyImages: 3, MaxQueuedImages: 2})
+	if l.DailyImages != 3 || l.MaxQueuedImages != 2 {
+		t.Fatal(l)
+	}
+}

--- a/internal/keys/budgets.go
+++ b/internal/keys/budgets.go
@@ -15,6 +15,7 @@ type Budgets map[string][]Budget
 func (l Limits) Budgets() Budgets {
 	l = AudioDefaults(l)
 	return Budgets{
+		"images": {{"images", "day", l.DailyImages}},
 		"tokens": {{"tokens", "minute", l.TPM}, {"tokens", "day", l.DailyTokens}},
 		"audio":  {{"seconds", "day", l.DailyAudioSeconds}},
 		"speech": {{"characters", "day", l.DailySpeechChars}},

--- a/internal/keys/budgets_test.go
+++ b/internal/keys/budgets_test.go
@@ -29,7 +29,7 @@ func TestLegacyKeyBudgetsDoNotRewriteFile(t *testing.T) {
 		t.Fatalf("keys: %v %v", list, err)
 	}
 	l := list[0].Limits
-	want := Budgets{"tokens": {{"tokens", "minute", 1234}, {"tokens", "day", 5678}}, "audio": {{"seconds", "day", 3600}}, "speech": {{"characters", "day", 200000}}}
+	want := Budgets{"images": {{"images", "day", 20}}, "tokens": {{"tokens", "minute", 1234}, {"tokens", "day", 5678}}, "audio": {{"seconds", "day", 3600}}, "speech": {{"characters", "day", 200000}}}
 	if !reflect.DeepEqual(l.Budgets(), want) {
 		t.Fatalf("budgets: %+v", l.Budgets())
 	}

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -18,6 +18,8 @@ const (
 // Limits are per-key. Zero means "use the default" at creation time and "unlimited / upstream's"
 // once stored (MaxContext 0 = upstream context; Models empty = all models).
 type Limits struct {
+	DailyImages       int      `json:"daily_images"`
+	MaxQueuedImages   int      `json:"max_queued_images"`
 	DailyAudioSeconds int      `json:"daily_audio_seconds"`
 	DailySpeechChars  int      `json:"daily_speech_chars"`
 	RPM               int      `json:"rpm"`
@@ -31,7 +33,7 @@ type Limits struct {
 
 // DefaultLimits are applied at `keys add` when a field is zero.
 func DefaultLimits() Limits {
-	return Limits{DailyAudioSeconds: 3600, DailySpeechChars: 200000, RPM: 20, TPM: 20000, MaxConcurrent: 1, MaxOutputTokens: 4096, MaxContext: 0, DailyTokens: 200000}
+	return Limits{DailyImages: 20, MaxQueuedImages: 8, DailyAudioSeconds: 3600, DailySpeechChars: 200000, RPM: 20, TPM: 20000, MaxConcurrent: 1, MaxOutputTokens: 4096, MaxContext: 0, DailyTokens: 200000}
 }
 
 // Key is one friend. SecretHash is "sha256:<hex>" of the invite secret; the secret itself is never stored.
@@ -87,6 +89,16 @@ func AudioDefaults(l Limits) Limits {
 	}
 	if l.DailySpeechChars == 0 {
 		l.DailySpeechChars = 200000
+	}
+	return ImageDefaults(l)
+}
+
+func ImageDefaults(l Limits) Limits {
+	if l.DailyImages == 0 {
+		l.DailyImages = 20
+	}
+	if l.MaxQueuedImages == 0 {
+		l.MaxQueuedImages = 8
 	}
 	return l
 }

--- a/internal/run/consumer.go
+++ b/internal/run/consumer.go
@@ -8,6 +8,9 @@ import (
 
 // Policy is registered by the host alongside a kind, never supplied by a friend.
 type Policy struct {
+	Serial         bool
+	QueueLimit     func(string) (int, error)
+	Validate       func(json.RawMessage) error
 	DeferredCancel bool // A running attempt finishes; successful completion remains Done.
 	JoinCancel     bool // An active consumer must return before cancellation becomes terminal.
 }

--- a/internal/run/images.go
+++ b/internal/run/images.go
@@ -1,0 +1,246 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const MaxImage = 8 << 20
+const ImageBudget = 256 << 20
+
+type Batch struct {
+	ID    string `json:"id"`
+	Index int    `json:"index"`
+	Count int    `json:"count"`
+}
+type ImageInput struct {
+	ClientRequestID string `json:"client_request_id,omitempty"`
+	Prompt          string `json:"prompt"`
+	Conversation    string `json:"conversation,omitempty"`
+}
+type ImageOutput struct {
+	URL       string    `json:"url"`
+	MIME      string    `json:"mime"`
+	Width     int       `json:"w"`
+	Height    int       `json:"h"`
+	Bytes     int       `json:"bytes"`
+	ExpiresAt time.Time `json:"expiresAt"`
+	Gone      bool      `json:"gone,omitempty"`
+}
+
+func ValidateImage(input json.RawMessage) error {
+	var in ImageInput
+	if json.Unmarshal(input, &in) != nil || strings.TrimSpace(in.Prompt) == "" || len(input) > MaxInput || len(in.Conversation) > 128 || len(in.ClientRequestID) > 128 || strings.Contains(in.Prompt, "<sd_cpp_extra_args>") {
+		return ErrInvalid
+	}
+	return nil
+}
+func ImageKind(_ context.Context, r Run) (Decision, error) {
+	if err := ValidateImage(r.Input); err != nil {
+		return Decision{}, err
+	}
+	if len(r.Attempts) > 0 {
+		return Decision{Output: r.Attempts[len(r.Attempts)-1].Output}, nil
+	}
+	return Decision{Step: &Step{Route: "/v1/images/generations", Input: r.Input, RunID: r.ID}}, nil
+}
+func imageOutput(r Run) (ImageOutput, bool) {
+	var out ImageOutput
+	if r.Kind != "image" || json.Unmarshal(r.Output, &out) != nil {
+		return ImageOutput{}, false
+	}
+	return out, out.URL != ""
+}
+func (s *Store) artifactPath(key, rid string) string {
+	return filepath.Join(s.root, key, "images", rid)
+}
+
+// Artifact bytes have their own budget. State and attempt outputs contain metadata only.
+func (s *Store) PutImage(key, rid string, raw []byte, mime string, w, h int) (json.RawMessage, error) {
+	if len(raw) == 0 || len(raw) > MaxImage || (mime != "image/png" && mime != "image/jpeg") {
+		return nil, ErrLimit
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, err := s.load(key)
+	if err != nil {
+		return nil, err
+	}
+	if err = s.sweepImages(key, v); err != nil {
+		return nil, err
+	}
+	v = s.data[key]
+	old, ok := v.Runs[rid]
+	if !ok || old.Kind != "image" || terminal(old.State) {
+		return nil, ErrNotFound
+	}
+	if err = privateDir(filepath.Dir(s.artifactPath(key, rid))); err != nil {
+		return nil, err
+	}
+	budget := s.imageBudget
+	if budget == 0 {
+		budget = ImageBudget
+	}
+	next := clone(v)
+	type held struct {
+		id     string
+		output ImageOutput
+	}
+	var heldImages []held
+	total := len(raw)
+	for id, r := range next.Runs {
+		if o, ok := imageOutput(r); ok && !o.Gone {
+			heldImages = append(heldImages, held{id, o})
+			total += o.Bytes
+		}
+	}
+	sort.Slice(heldImages, func(i, j int) bool {
+		if heldImages[i].output.ExpiresAt.Equal(heldImages[j].output.ExpiresAt) {
+			return heldImages[i].id < heldImages[j].id
+		}
+		return heldImages[i].output.ExpiresAt.Before(heldImages[j].output.ExpiresAt)
+	})
+	var evict []string
+	for _, a := range heldImages {
+		if total <= budget && a.output.ExpiresAt.After(s.now()) {
+			continue
+		}
+		r := next.Runs[a.id]
+		a.output.Gone = true
+		r.Output, _ = json.Marshal(a.output)
+		next.Runs[a.id] = r
+		total -= a.output.Bytes
+		evict = append(evict, a.id)
+	}
+	path := s.artifactPath(key, rid)
+	if _, err = os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		if err == nil {
+			return nil, ErrConflict
+		}
+		return nil, err
+	}
+	if err = atomicWrite(path, raw); err != nil {
+		return nil, err
+	}
+	out := ImageOutput{URL: "/v1/images/outputs/" + rid, MIME: mime, Width: w, Height: h, Bytes: len(raw), ExpiresAt: s.now().UTC().Add(Retention)}
+	result, _ := json.Marshal(out)
+	old.Output = result
+	next.Runs[rid] = old
+	if err = s.commit(key, next, &Event{RunID: rid, State: old.State, Time: s.now().UTC()}); err != nil {
+		_ = os.Remove(path)
+		return nil, err
+	}
+	for _, id := range evict {
+		if err = os.Remove(s.artifactPath(key, id)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			s.broken[key] = err
+			return nil, err
+		}
+	}
+	return result, nil
+}
+func (s *Store) ReadImage(key, rid string) ([]byte, ImageOutput, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, err := s.load(key)
+	if err != nil {
+		return nil, ImageOutput{}, err
+	}
+	r, ok := v.Runs[rid]
+	o, has := imageOutput(r)
+	if !ok || !has || o.Gone || !o.ExpiresAt.After(s.now()) {
+		return nil, o, ErrNotFound
+	}
+	path := s.artifactPath(key, rid)
+	if info, e := os.Lstat(filepath.Dir(path)); e != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, o, ErrNotFound
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Size() > MaxImage {
+		return nil, o, ErrNotFound
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, o, ErrNotFound
+	}
+	defer f.Close()
+	raw, err := io.ReadAll(io.LimitReader(f, MaxImage+1))
+	if len(raw) > MaxImage {
+		return nil, o, ErrLimit
+	}
+	return raw, o, err
+}
+func (s *Store) DiscardImage(key, rid string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, err := s.load(key)
+	if err != nil {
+		return err
+	}
+	r, ok := v.Runs[rid]
+	o, has := imageOutput(r)
+	if !ok || !has {
+		return ErrNotFound
+	}
+	if o.Gone {
+		return nil
+	}
+	o.Gone = true
+	r.Output, _ = json.Marshal(o)
+	next := clone(v)
+	next.Runs[rid] = r
+	if err = s.commit(key, next, &Event{RunID: rid, State: r.State, Time: s.now().UTC()}); err != nil {
+		return err
+	}
+	if err = os.Remove(s.artifactPath(key, rid)); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// Called under the store lock after expiry. Removes orphaned files after an interrupted commit too.
+func (s *Store) sweepImages(key string, v *snapshot) error {
+	dir := filepath.Join(s.root, key, "images")
+	if info, e := os.Lstat(dir); errors.Is(e, os.ErrNotExist) {
+		return nil
+	} else if e != nil {
+		return e
+	} else if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return ErrInvalid
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	next := clone(v)
+	changed := false
+	for id, r := range next.Runs {
+		if o, ok := imageOutput(r); ok && !o.Gone && !o.ExpiresAt.After(s.now()) {
+			o.Gone = true
+			r.Output, _ = json.Marshal(o)
+			next.Runs[id] = r
+			changed = true
+		}
+	}
+	if changed {
+		if err = s.commit(key, next, nil); err != nil {
+			return err
+		}
+	}
+	for _, e := range entries {
+		r, exists := next.Runs[e.Name()]
+		o, ok := imageOutput(r)
+		if !exists || !ok || o.Gone {
+			if err = os.Remove(filepath.Join(dir, e.Name())); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/run/images_test.go
+++ b/internal/run/images_test.go
@@ -1,0 +1,251 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func imageIn(prompt string) json.RawMessage {
+	b, _ := json.Marshal(ImageInput{Prompt: prompt})
+	return b
+}
+func untilImage(t *testing.T, s *Store, key, rid string, state State) Run {
+	t.Helper()
+	until := time.Now().Add(3 * time.Second)
+	for time.Now().Before(until) {
+		r, e := s.Get(key, rid)
+		if e == nil && r.State == state {
+			return r
+		}
+		time.Sleep(time.Millisecond)
+	}
+	r, _ := s.Get(key, rid)
+	t.Fatalf("wanted %s: %+v", state, r)
+	return r
+}
+func TestImageWorkerPriorityAndDeferredCancel(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+	started := make(chan string, 4)
+	release := make(chan struct{}, 4)
+	var mu sync.Mutex
+	active, peak := 0, 0
+	exec := func(ctx context.Context, _ string, step Step, acquired func() error) (StepResult, error) {
+		if err := acquired(); err != nil {
+			return StepResult{}, err
+		}
+		mu.Lock()
+		active++
+		if active > peak {
+			peak = active
+		}
+		mu.Unlock()
+		started <- step.RunID
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return StepResult{}, ctx.Err()
+		}
+		mu.Lock()
+		active--
+		mu.Unlock()
+		return StepResult{Output: json.RawMessage(`{"url":"image"}`), Dispatched: true, Settled: true}, nil
+	}
+	m, _ := New(s, exec, nil)
+	m.Register("image", ImageKind, Policy{Serial: true, DeferredCancel: true, Validate: ValidateImage})
+	defer m.Close()
+	first, _ := m.Submit("key", "image", "planted", imageIn("first"))
+	if <-started != first.ID {
+		t.Fatal("first")
+	}
+	planted, _ := m.Submit("key", "image", "planted", imageIn("planted"))
+	interactive, _ := m.Submit("key", "image", "interactive", imageIn("interactive"))
+	if m.Position("image", interactive.ID) != 1 {
+		t.Fatal("interactive not first")
+	}
+	r, e := m.Cancel("key", first.ID)
+	if e != nil || r.State != Running || !r.CancelRequested {
+		t.Fatal(r, e)
+	}
+	release <- struct{}{}
+	untilImage(t, s, "key", first.ID, Done)
+	if <-started != interactive.ID {
+		t.Fatal("priority")
+	}
+	if _, e = m.Cancel("key", planted.ID); e != nil {
+		t.Fatal(e)
+	}
+	untilImage(t, s, "key", planted.ID, Cancelled)
+	release <- struct{}{}
+	untilImage(t, s, "key", interactive.ID, Done)
+	if peak != 1 {
+		t.Fatal("parallel images", peak)
+	}
+}
+func TestImageBatchCapIsAtomic(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+	rows, e := s.CreateBatch("key", "image", "planted", []json.RawMessage{imageIn("a"), imageIn("b")}, 2)
+	if e != nil || len(rows) != 2 || rows[0].Batch.ID != rows[1].Batch.ID || rows[1].Batch.Index != 1 {
+		t.Fatal(rows, e)
+	}
+	if _, e = s.CreateBatch("key", "image", "planted", []json.RawMessage{imageIn("c"), imageIn("d")}, 2); !errors.Is(e, ErrQueueLimit) {
+		t.Fatal(e)
+	}
+	all, _ := s.List("key")
+	if len(all) != 2 {
+		t.Fatal("partial admission")
+	}
+	rows[0].Input[0] = 'x'
+	r, _ := s.Get("key", rows[0].ID)
+	if !json.Valid(r.Input) {
+		t.Fatal("aliased batch")
+	}
+}
+func TestImageArtifactsEvictDiscardExpireAndIsolate(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+	s.imageBudget = 8
+	makeImage := func(name string) Run {
+		r, e := s.Create("key", "image", "interactive", imageIn(name))
+		if e != nil {
+			t.Fatal(e)
+		}
+		if _, e = s.PutImage("key", r.ID, []byte("four"), "image/png", 1, 1); e != nil {
+			t.Fatal(e)
+		}
+		return r
+	}
+	a := makeImage("a")
+	b := makeImage("b")
+	c := makeImage("c")
+	if _, o, e := s.ReadImage("key", a.ID); !errors.Is(e, ErrNotFound) || !o.Gone {
+		t.Fatal("oldest not evicted", o, e)
+	}
+	if _, _, e := s.ReadImage("other", b.ID); !errors.Is(e, ErrNotFound) {
+		t.Fatal("cross key", e)
+	}
+	if e := s.DiscardImage("key", b.ID); e != nil {
+		t.Fatal(e)
+	}
+	if e := s.DiscardImage("key", b.ID); e != nil {
+		t.Fatal("discard not idempotent", e)
+	}
+	if _, _, e := s.ReadImage("key", c.ID); e != nil {
+		t.Fatal(e)
+	}
+	_ = os.Remove(s.artifactPath("key", c.ID))
+	_ = os.Symlink("/etc/hosts", s.artifactPath("key", c.ID))
+	if _, _, e := s.ReadImage("key", c.ID); !errors.Is(e, ErrNotFound) {
+		t.Fatal("symlink read", e)
+	}
+	s.now = func() time.Time { return time.Now().Add(Retention + time.Hour) }
+	if _, _, e := s.ReadImage("key", c.ID); !errors.Is(e, ErrNotFound) {
+		t.Fatal("expired read", e)
+	}
+	if _, e := s.PutImage("key", c.ID, make([]byte, MaxImage+1), "image/png", 1, 1); !errors.Is(e, ErrLimit) {
+		t.Fatal("artifact cap", e)
+	}
+}
+
+func TestImageExpiryRetainsGoneMetadataAndRestartDoesNotReplay(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := NewStore(dir)
+	now := time.Now()
+	s.now = func() time.Time { return now }
+	r, _ := s.Create("key", "image", "interactive", imageIn("one"))
+	meta, e := s.PutImage("key", r.ID, []byte("png"), "image/png", 1, 1)
+	if e != nil {
+		t.Fatal(e)
+	}
+	now = now.Add(time.Hour)
+	_, e = s.change("key", r.ID, func(v *Run) error { v.State = Done; v.Output = meta; return nil })
+	if e != nil {
+		t.Fatal(e)
+	}
+	now = now.Add(Retention - time.Minute)
+	m, _ := New(s, nil, nil)
+	defer m.Close()
+	if e = m.Sweep(); e != nil {
+		t.Fatal(e)
+	}
+	kept, e := s.Get("key", r.ID)
+	o, ok := imageOutput(kept)
+	if e != nil || !ok || !o.Gone {
+		t.Fatal(kept, e)
+	}
+	if _, e = os.Stat(s.artifactPath("key", r.ID)); !errors.Is(e, os.ErrNotExist) {
+		t.Fatal(e)
+	}
+	live, _ := s.Create("key", "image", "planted", imageIn("never replay"))
+	s2, e := NewStore(dir)
+	if e != nil {
+		t.Fatal(e)
+	}
+	replayed := false
+	m2, e := New(s2, func(context.Context, string, Step, func() error) (StepResult, error) {
+		replayed = true
+		return StepResult{}, nil
+	}, map[string]Kind{"image": ImageKind})
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer m2.Close()
+	got, _ := s2.Get("key", live.ID)
+	if got.State != Failed || replayed {
+		t.Fatal(got, replayed)
+	}
+}
+
+func TestDiscardBeforeStepFinishDoesNotResurrectMetadata(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+	r, _ := s.Create("key", "image", "interactive", imageIn("one"))
+	meta, e := s.PutImage("key", r.ID, []byte("png"), "image/png", 1, 1)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if e = s.DiscardImage("key", r.ID); e != nil {
+		t.Fatal(e)
+	}
+	m := &Manager{Store: s}
+	m.finish("key", r.ID, Done, "", meta)
+	r, _ = s.Get("key", r.ID)
+	o, ok := imageOutput(r)
+	if !ok || !o.Gone || r.State != Done {
+		t.Fatal(r)
+	}
+}
+
+func TestImageCancelAfterOutputBeforeFinalSnapshot(t *testing.T) {
+	s, _ := NewStore(t.TempDir())
+	ready, finish := make(chan struct{}), make(chan struct{})
+	m, _ := New(s, func(_ context.Context, key string, step Step, acquired func() error) (StepResult, error) {
+		if e := acquired(); e != nil {
+			return StepResult{}, e
+		}
+		output, e := s.PutImage(key, step.RunID, []byte("image"), "image/png", 1, 1)
+		return StepResult{Output: output, Dispatched: true, Settled: true}, e
+	}, nil)
+	m.Register("image", func(ctx context.Context, r Run) (Decision, error) {
+		if len(r.Attempts) > 0 {
+			close(ready)
+			<-finish
+		}
+		return ImageKind(ctx, r)
+	}, Policy{Serial: true, DeferredCancel: true})
+	defer m.Close()
+	defer close(finish)
+	r, e := m.Submit("key", "image", "interactive", imageIn("one"))
+	if e != nil {
+		t.Fatal(e)
+	}
+	<-ready
+	r, e = m.Cancel("key", r.ID)
+	if e != nil || r.State != Running || !r.CancelRequested {
+		t.Fatalf("completed image reverted: %+v %v", r, e)
+	}
+	finish <- struct{}{}
+	untilImage(t, s, "key", r.ID, Done)
+}

--- a/internal/run/manager.go
+++ b/internal/run/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"sort"
 	"sync"
 	"time"
 )
@@ -24,6 +25,7 @@ type Manager struct {
 type execution struct {
 	cancel context.CancelFunc
 	answer chan struct{}
+	kind   string
 }
 
 func New(s *Store, exec Executor, kinds map[string]Kind) (*Manager, error) {
@@ -51,26 +53,100 @@ func New(s *Store, exec Executor, kinds map[string]Kind) (*Manager, error) {
 	return m, nil
 }
 func (m *Manager) Submit(key, kind, priority string, input json.RawMessage) (Run, error) {
+	rows, err := m.SubmitBatch(key, kind, priority, []json.RawMessage{input})
+	if err != nil {
+		return Run{}, err
+	}
+	return rows[0], nil
+}
+func (m *Manager) SubmitBatch(key, kind, priority string, inputs []json.RawMessage) ([]Run, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.ctx.Err() != nil {
-		return Run{}, ErrConflict
+		return nil, ErrConflict
 	}
 	if m.Kinds[kind] == nil {
-		return Run{}, ErrInvalid
+		return nil, ErrInvalid
 	}
 	if priority == "" {
 		priority = "interactive"
 	}
-	r, err := m.Store.Create(key, kind, priority, input)
-	if err == nil {
-		m.start(r)
+	p := m.Policies[kind]
+	cap := MaxLiveKey
+	if p.QueueLimit != nil {
+		var err error
+		cap, err = p.QueueLimit(key)
+		if err != nil {
+			return nil, err
+		}
 	}
-	return r, err
+	for _, in := range inputs {
+		if p.Validate != nil {
+			if err := p.Validate(in); err != nil {
+				return nil, err
+			}
+		}
+	}
+	rows, err := m.Store.CreateBatch(key, kind, priority, inputs, cap)
+	if err == nil {
+		if p.Serial {
+			m.schedule(kind)
+		} else {
+			for _, r := range rows {
+				m.start(r)
+			}
+		}
+	}
+	return rows, err
+}
+func (m *Manager) queued(kind string) []Run {
+	summaries, _ := m.Store.List("")
+	var rows []Run
+	for _, r := range summaries {
+		if r.Kind == kind && r.State == Queued {
+			if v, err := m.Store.Get(r.KeyID, r.ID); err == nil {
+				rows = append(rows, v)
+			}
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.Priority != b.Priority {
+			return a.Priority == "interactive"
+		}
+		if a.Created.Equal(b.Created) {
+			return a.ID < b.ID
+		}
+		return a.Created.Before(b.Created)
+	})
+	return rows
+}
+func (m *Manager) schedule(kind string) {
+	if m.ctx.Err() != nil {
+		return
+	}
+	for _, a := range m.active {
+		if a.kind == kind {
+			return
+		}
+	}
+	if rows := m.queued(kind); len(rows) > 0 {
+		m.start(rows[0])
+	}
+}
+func (m *Manager) Position(kind, rid string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for i, r := range m.queued(kind) {
+		if r.ID == rid {
+			return i + 1
+		}
+	}
+	return 0
 }
 func (m *Manager) start(r Run) {
 	ctx, cancel := context.WithCancel(m.ctx)
-	worker := &execution{cancel: cancel, answer: make(chan struct{}, 1)}
+	worker := &execution{cancel: cancel, kind: r.Kind, answer: make(chan struct{}, 1)}
 	m.active[r.ID] = worker
 	m.wg.Add(1)
 	go func() {
@@ -79,6 +155,9 @@ func (m *Manager) start(r Run) {
 			m.mu.Lock()
 			if m.active[r.ID] == worker {
 				delete(m.active, r.ID)
+				if m.Policies[r.Kind].Serial {
+					m.schedule(r.Kind)
+				}
 			}
 			m.mu.Unlock()
 			cancel()
@@ -123,7 +202,7 @@ func (m *Manager) Cancel(key, rid string) (Run, error) {
 		return nil
 	})
 	if err == nil {
-		if worker := m.active[rid]; worker != nil && !(old.State == Running && m.Policies[old.Kind].DeferredCancel) {
+		if worker := m.active[rid]; worker != nil && !(r.State == Running && m.Policies[r.Kind].DeferredCancel) {
 			worker.cancel()
 		}
 	}
@@ -145,7 +224,10 @@ func (m *Manager) finish(key, rid string, st State, reason string, output json.R
 		}
 		v.State = st
 		v.Reason = reason
-		v.Output = output
+		// Artifact metadata can change (Discard/eviction) between persistence and step finish.
+		if _, stored := imageOutput(*v); !stored {
+			v.Output = output
+		}
 		return nil
 	})
 }
@@ -207,6 +289,8 @@ func (m *Manager) attempt(ctx context.Context, r Run, step Step, live bool) (Run
 				return ErrConflict
 			}
 			v.State = Running
+			now := m.Store.now().UTC()
+			v.Started = &now
 			return nil
 		})
 		return e
@@ -230,6 +314,11 @@ func (m *Manager) attempt(ctx context.Context, r Run, step Step, live bool) (Run
 		} else if stepErr != nil || len(result.Output) > MaxOutput || !json.Valid(result.Output) {
 			v.State = Failed
 			v.Reason = "step failed"
+			if stepErr != nil {
+				v.Reason = stepErr.Error()
+			}
+		} else if _, stored := imageOutput(*v); stored && m.Policies[v.Kind].DeferredCancel {
+			v.State = Running // the completed image remains running until its terminal snapshot
 		} else {
 			v.State = Queued
 		}
@@ -271,6 +360,9 @@ func (m *Manager) Sweep() error {
 			if err = s.commit(key, next, nil); err != nil {
 				return err
 			}
+		}
+		if err = s.sweepImages(key, next); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -25,14 +25,15 @@ type snapshot struct {
 	Retained map[string]Retained `json:"retained,omitempty"`
 }
 type Store struct {
-	mu       sync.Mutex
-	root     string
-	data     map[string]*snapshot
-	broken   map[string]error
-	subs     map[string]map[chan Event]bool
-	now      func() time.Time
-	write    func(string, []byte) error
-	reserved map[string]map[string]*reservation
+	mu          sync.Mutex
+	root        string
+	data        map[string]*snapshot
+	broken      map[string]error
+	subs        map[string]map[chan Event]bool
+	now         func() time.Time
+	write       func(string, []byte) error
+	reserved    map[string]map[string]*reservation
+	imageBudget int
 }
 
 var safeID = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,80}$`)
@@ -269,40 +270,73 @@ func (s *Store) change(key, rid string, fn func(*Run) error, retain ...func(*Ret
 	err = s.commit(key, v, &ev)
 	return clone(v).Runs[rid], err
 }
-func (s *Store) Create(key, kind, priority string, input json.RawMessage) (Run, error) {
-	if len(input) > MaxInput {
-		return Run{}, ErrLimit
+func (s *Store) CreateBatch(key, kind, priority string, inputs []json.RawMessage, cap int) ([]Run, error) {
+	if len(inputs) == 0 || len(inputs) > MaxLiveKey {
+		return nil, ErrLimit
 	}
-	if !json.Valid(input) || (priority != "interactive" && priority != "planted") {
-		return Run{}, ErrInvalid
+	for _, input := range inputs {
+		if len(input) > MaxInput {
+			return nil, ErrLimit
+		}
+		if !json.Valid(input) || (priority != "interactive" && priority != "planted") {
+			return nil, ErrInvalid
+		}
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	v, err := s.load(key)
 	if err != nil {
-		return Run{}, err
+		return nil, err
 	}
-	keyLive, total := 0, 0
+	keyLive, total, queued := 0, 0, 0
 	for k, d := range s.data {
 		for _, r := range d.Runs {
 			if !terminal(r.State) {
 				total++
 				if k == key {
 					keyLive++
+					if r.Kind == kind && r.State == Queued {
+						queued++
+					}
 				}
 			}
 		}
 	}
-	if keyLive >= MaxLiveKey || total >= MaxLiveHost || len(v.Runs) >= MaxRuns {
-		return Run{}, ErrLimit
+	if keyLive+len(inputs) > MaxLiveKey || total+len(inputs) > MaxLiveHost || len(v.Runs)+len(inputs) > MaxRuns {
+		return nil, ErrLimit
 	}
+	if queued+len(inputs) > cap {
+		return nil, ErrQueueLimit
+	}
+	next := clone(v)
 	now := s.now().UTC()
-	r := Run{ID: id("r_"), KeyID: key, Kind: kind, Priority: priority, State: Queued, Created: now, Updated: now, Expires: now.Add(MaxAge), Input: append(json.RawMessage(nil), input...), Attempts: []Attempt{}}
-	v = clone(v)
-	v.Runs[r.ID] = r
-	err = s.commit(key, v, &Event{RunID: r.ID, State: r.State, Time: now})
-	return clone(v).Runs[r.ID], err
+	batchID := id("b_")
+	rows := make([]Run, 0, len(inputs))
+	for i, input := range inputs {
+		r := Run{ID: id("r_"), KeyID: key, Kind: kind, Priority: priority, State: Queued, Created: now.Add(time.Duration(i)), Updated: now, Expires: now.Add(MaxAge), Input: append(json.RawMessage(nil), input...), Attempts: []Attempt{}}
+		if kind == "image" {
+			r.Batch = &Batch{batchID, i, len(inputs)}
+		}
+		next.Runs[r.ID] = r
+		rows = append(rows, r)
+	}
+	// A batch has one durable admission point. Its event prompts the image list to refresh all siblings.
+	if err = s.commit(key, next, &Event{RunID: rows[0].ID, State: Queued, Time: now}); err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i] = clone(next).Runs[rows[i].ID]
+	}
+	return rows, nil
 }
+func (s *Store) Create(key, kind, priority string, input json.RawMessage) (Run, error) {
+	rows, err := s.CreateBatch(key, kind, priority, []json.RawMessage{input}, MaxLiveKey)
+	if err != nil {
+		return Run{}, err
+	}
+	return rows[0], nil
+}
+
 func (s *Store) Get(key, rid string) (Run, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/run/types.go
+++ b/internal/run/types.go
@@ -21,10 +21,11 @@ const (
 )
 
 var (
-	ErrNotFound = errors.New("run not found")
-	ErrLimit    = errors.New("run limit reached")
-	ErrInvalid  = errors.New("invalid run request")
-	ErrConflict = errors.New("run state changed")
+	ErrQueueLimit = errors.New("image queue limit reached")
+	ErrNotFound   = errors.New("run not found")
+	ErrLimit      = errors.New("run limit reached")
+	ErrInvalid    = errors.New("invalid run request")
+	ErrConflict   = errors.New("run state changed")
 )
 
 type State string
@@ -49,6 +50,8 @@ type Attempt struct {
 	Output              json.RawMessage `json:"output,omitempty"`
 }
 type Run struct {
+	Started         *time.Time      `json:"started,omitempty"`
+	Batch           *Batch          `json:"batch,omitempty"`
 	ID              string          `json:"id"`
 	KeyID           string          `json:"key_id"`
 	Kind            string          `json:"kind"`
@@ -87,6 +90,7 @@ type Event struct {
 	Runs      []Summary `json:"runs,omitempty"`
 }
 type Step struct {
+	RunID string
 	Route string
 	Input json.RawMessage
 }
@@ -104,5 +108,5 @@ type Decision struct {
 	Output json.RawMessage
 }
 
-// Kind is host-registered code, not a client-supplied program. Production registers none yet.
+// Kind is host-registered code, not a client-supplied program. Production registers image when configured.
 type Kind func(context.Context, Run) (Decision, error)

--- a/internal/upstream/images.go
+++ b/internal/upstream/images.go
@@ -1,0 +1,25 @@
+package upstream
+
+import (
+	"context"
+	"net/http"
+)
+
+// ImageEngine shares the explicit engine probe/transport; it needs no tokenizer.
+type ImageEngine interface {
+	Info() Info
+	Refresh(context.Context) error
+	ImageDo(context.Context, []byte) (*http.Response, error)
+}
+type imageClient struct{ AudioEngine }
+
+func OpenImages(ctx context.Context, url, key string) (ImageEngine, error) {
+	a, e := OpenAudio(ctx, url, key)
+	if e != nil || a == nil {
+		return nil, e
+	}
+	return &imageClient{a}, nil
+}
+func (i *imageClient) ImageDo(ctx context.Context, body []byte) (*http.Response, error) {
+	return i.AudioDo(ctx, "/v1/images/generations", "application/json", body)
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -45,6 +45,7 @@ type Recorder interface {
 // Counters are the live per-key numbers the gateway keeps in memory for limits and for /me.
 // Implemented by the gateway (002); exposed to admin status via the Snapshot interface.
 type KeyCounters struct {
+	TodayImages       int       `json:"today_images"`
 	TodayAudioSeconds float64   `json:"today_audio_seconds"`
 	TodaySpeechChars  int       `json:"today_speech_chars"`
 	InFlight          int       `json:"in_flight"`

--- a/packages/client/src/contract.ts
+++ b/packages/client/src/contract.ts
@@ -9,6 +9,8 @@ export interface Limits {
   daily_tokens: number;
   daily_audio_seconds?: number;
   daily_speech_chars?: number;
+  daily_images?: number;
+  max_queued_images?: number;
   models?: string[];
 }
 
@@ -17,13 +19,14 @@ export interface Me {
   agent?: boolean;
   key: { id: string; name: string; status: 'active' | 'paused' | 'revoked' };
   limits: Limits;
-  usage: { rpm_used: number; tpm_used: number; today_tokens: number; in_flight: number };
+  usage: { today_images?: number; rpm_used: number; tpm_used: number; today_tokens: number; in_flight: number };
   host: {
     name: string;
     upstream: { kind: string; healthy: boolean; model_context: number };
     models: string[];
     /** Per-model capability; null means the engine did not report it. */
     vision?: Record<string, boolean | null>;
+    images?: { model: string; retention_days: number; queue_cap: number; queued: number };
     audio?: { transcriptions: string | null; speech: string | null };
     relay: { region: string };
     /** The host runs with --log-prompts. Absent on a gateway older than ticket 006: absent = false. */
@@ -35,6 +38,7 @@ export type GatewayErrorCode =
   | 'invalid_key' | 'key_paused' | 'key_revoked' | 'model_not_allowed'
   | 'body_too_large' | 'context_too_long' | 'rate_limited' | 'concurrency_limited'
   | 'budget_exhausted' | 'queue_timeout' | 'upstream_down' | 'upstream_error'
+  | 'image_queue_full' | 'image_budget_exhausted'
   | 'audio_budget_exhausted' | 'speech_budget_exhausted' | 'images_not_supported'
   | 'invalid_request' | 'not_found' | 'client_closed';
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -16,6 +16,10 @@ export function hostAudio(me: Me, kind: 'transcriptions' | 'speech'): string | n
   return me.host.audio?.[kind] || null;
 }
 
+export function hostImages(me: Me): NonNullable<Me['host']['images']> | null {
+  return me.host.images?.model ? me.host.images : null;
+}
+
 /** The host's name, trimmed. It can be empty, and "You’re on ." is not a sentence: callers check. */
 export function hostName(me: Me): string {
   return me.host.name.trim();

--- a/web/src/fixtures/me/README.md
+++ b/web/src/fixtures/me/README.md
@@ -29,3 +29,9 @@ Post-deploy: `cd web && pnpm exec node dev/live-assert.mjs [URL]` (default /try)
 Set INVITE to use a specific invite without printing it. The script observes the
 empty chat's controls, so `listen: false` means no Listen button was rendered;
 it does not infer speech capability from an empty history. It never sends a chat.
+
+144: current.json also includes the additive image capability, image-limit defaults
+and zero image usage, using the same normalized compatibility identity/model. These
+new fields are covered by the real isolated-host `/me` proof and gateway tests; the
+older fixture fields retain their captured values. This fixture is now an explicit
+compatibility assembly, not a claim that every value came from one capture.

--- a/web/src/fixtures/me/current.json
+++ b/web/src/fixtures/me/current.json
@@ -12,13 +12,16 @@
     "max_concurrent": 1,
     "max_output_tokens": 4096,
     "max_context": 0,
-    "daily_tokens": 200000
+    "daily_tokens": 200000,
+    "daily_images": 20,
+    "max_queued_images": 8
   },
   "usage": {
     "rpm_used": 0,
     "tpm_used": 0,
     "today_tokens": 0,
-    "in_flight": 0
+    "in_flight": 0,
+    "today_images": 0
   },
   "host": {
     "name": "Compatibility host",
@@ -40,6 +43,12 @@
     "relay": {
       "region": "New York City"
     },
-    "log_prompts": false
+    "log_prompts": false,
+    "images": {
+      "model": "image-model",
+      "retention_days": 7,
+      "queue_cap": 8,
+      "queued": 0
+    }
   }
 }

--- a/web/src/host-compat.test.ts
+++ b/web/src/host-compat.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import ts from 'typescript';
-import { hostAudio, logsPrompts, modelVision, type Me } from './api';
+import { hostAudio, hostImages, logsPrompts, modelVision, type Me } from './api';
 import old from './fixtures/me/0.1.0.json';
 import current from './fixtures/me/current.json';
 
@@ -9,7 +9,7 @@ const source = ts.createSourceFile('contract.ts', readFileSync(new URL('../../pa
 const me = source.statements.find((s): s is ts.InterfaceDeclaration => ts.isInterfaceDeclaration(s) && s.name.text === 'Me')!;
 const host = (me.members.find((m) => m.name?.getText(source) === 'host') as ts.PropertySignature).type as ts.TypeLiteralNode;
 // Explicit extension inventory (082's size-1 alternative to a generated Go schema).
-const optional = ['audio', 'log_prompts', 'vision'];
+const optional = ['audio', 'images', 'log_prompts', 'vision'];
 
 describe('shipped host capabilities', () => {
   it('keeps additive fields optional and requires an explicit inventory update', () => {
@@ -17,7 +17,7 @@ describe('shipped host capabilities', () => {
     for (const m of host.members) {
       if (!(m.name!.getText(source) in old.host)) expect((m as ts.PropertySignature).questionToken).toBeDefined();
     }
-    expect(Object.keys(current.host).sort()).toEqual(['audio', 'log_prompts', 'models', 'name', 'relay', 'upstream', 'vision']);
+    expect(Object.keys(current.host).sort()).toEqual(['audio', 'images', 'log_prompts', 'models', 'name', 'relay', 'upstream', 'vision']);
   });
   it('requires current fixture coverage for Go wire field names', () => {
     const proxy = readFileSync(new URL('../../internal/gateway/proxy.go', import.meta.url), 'utf8');
@@ -36,6 +36,8 @@ describe('shipped host capabilities', () => {
     expect(modelVision(old as Me, 'compat-model')).toBeNull();
     expect(hostAudio(old as Me, 'transcriptions')).toBeNull();
     expect(hostAudio(old as Me, 'speech')).toBeNull();
+    expect(hostImages(old as Me)).toBeNull();
+    expect(hostImages(current as Me)?.model).toBe('image-model');
     expect(modelVision(current as Me, 'compat-model')).toBe(true);
     expect(modelVision(current as Me, 'missing')).toBeNull();
     const me = { ...current, host: { ...current.host, vision: { text: false, unknown: null }, audio: { transcriptions: 'asr-model', speech: null } } } as Me;


### PR DESCRIPTION
Adds durable image jobs through an explicitly configured images engine. A single worker prioritizes interactive asks; atomic batches share an ID, queued cancellation stops immediately, and cancellation during generation keeps the finished image. Image reservations and RPM use the existing request owner without consuming text/audio concurrency.

Outputs are bounded PNG/JPEG artifacts scoped to the key, with expiry, oldest-first eviction, authenticated download and discard. The synchronous generations route uses the same jobs. The exact app contract and optional `/me` fields are documented in `docs/ARCHITECTURE.md`; 144b's app implementation is separate.

Validation: full Go race suite (650 passed / 0 failed / 3 opt-in skipped); combined 116b consumer and image cancellation tests; host compatibility (11/0/0); real pinned sd.cpp FLUX.2-klein-4B-Q8_0 proof with an isolated Ollama/host. During generation the same MaxConcurrent=1 key received a chat response; queued cancellation, deferred completion, batch correlation, Save/Discard, and sync generation passed. `make check`: CHECK OK. One earlier landing-video timeout passed on retry with the proof engines stopped.
