### PR TITLE
144c: Queue image artifact reads and retry gallery throttles

### DIFF
--- a/web/src/artifact-gallery.test.ts
+++ b/web/src/artifact-gallery.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from 'vitest';
+import { chromium } from 'playwright';
+import { createServer } from 'vite';
+
+// Render the real sheet, rather than a test-only queue consumer. Each of its eight
+// tiles sees one 429; successful responses keep their bodies open to measure slots.
+it('renders all eight tiles after one 429 round, with four complete reads at most', async () => {
+  const fixture = `<!doctype html><div id="root"></div><script type="module">
+    import React from 'react';
+    import { createRoot } from 'react-dom/client';
+    import { ImagesSheet } from '/src/ui/ImageJobs.tsx';
+    const metrics = window.metrics = { active: 0, peak: 0, attempts: {}, waits: [], total: 0 };
+    const rejectedAt = {};
+    const canvas = document.createElement('canvas'); canvas.width = canvas.height = 1;
+    const png = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+    const bytes = new Uint8Array(await png.arrayBuffer());
+    const transport = { async fetch(path, init) {
+      if (new Headers(init.headers).get('authorization') !== 'Bearer fixture') throw Error('Missing auth');
+      const id = path.split('/').pop();
+      metrics.total++; metrics.active++; metrics.peak = Math.max(metrics.peak, metrics.active);
+      const attempt = metrics.attempts[id] = (metrics.attempts[id] || 0) + 1;
+      if (attempt > 1) metrics.waits.push(performance.now() - rejectedAt[id]);
+      await new Promise(resolve => setTimeout(resolve, 30));
+      if (attempt === 1) {
+        metrics.active--; rejectedAt[id] = performance.now();
+        return new Response(JSON.stringify({error:{code:'concurrency_limited',message:'too many images loading at once; retry in a second'}}), {status:429,headers:{'Retry-After':'1','Content-Type':'application/json'}});
+      }
+      return new Response(new ReadableStream({ start(controller) {
+        setTimeout(() => { controller.enqueue(bytes); controller.close(); metrics.active--; }, 60);
+      }}), {headers:{'Content-Type':'image/png'}});
+    }};
+    const now = new Date().toISOString();
+    const jobs = Array.from({length:8}, (_,i) => ({id:'tile-'+i,kind:'image',key_id:'key',state:'done',created:now,updated:now,expires:now,cancel_requested:false,input:{prompt:'Picture '+i},batch:{id:'batch',index:i,count:8},attempts:[],output:{url:'ignored',mime:'image/png',w:1,h:1,bytes:bytes.length,expiresAt:new Date(Date.now()+86400000).toISOString()}}));
+    const live = {transport,secret:'fixture',offline:false,me:{host:{name:'Fixture',images:{model:'image-model',retention_days:7}}}};
+    const noop = () => {};
+    createRoot(document.getElementById('root')).render(React.createElement(ImagesSheet,{jobs,live,connected:true,disabled:false,pending:new Set(),onClose:noop,onEdit:noop,onConversation:noop,conversationTitle:()=> 'Chat',onCancel:noop,onDiscard:noop}));
+  </script>`;
+  const server = await createServer({ configFile: false, root: process.cwd(), server: { host: '127.0.0.1', port: 0 }, plugins: [{
+    name: 'eight-tile-fixture', configureServer(vite) {
+      vite.middlewares.use((req, res, next) => {
+        if (req.url !== '/gallery') { next(); return; }
+        void vite.transformIndexHtml('/gallery', fixture).then((html) => { res.setHeader('Content-Type', 'text/html'); res.end(html); });
+      });
+    },
+  }] });
+  let browser: Awaited<ReturnType<typeof chromium.launch>> | undefined;
+  try {
+    browser = await chromium.launch({ headless: true });
+    await server.listen();
+    const page = await browser.newPage();
+    const errors: string[] = []; page.on('pageerror', (error) => errors.push(error.message));
+    await page.goto(`${server.resolvedUrls!.local[0]}gallery`);
+    await page.waitForFunction(() => (window as unknown as {metrics:{total:number}}).metrics?.total === 8);
+    expect(await page.locator('[data-image-job]').count()).toBe(8);
+    expect(await page.locator('body').innerText()).not.toContain('too many images loading');
+    await page.waitForFunction(() => [...document.querySelectorAll<HTMLImageElement>('[data-image-job] img')].filter((img) => img.complete && img.naturalWidth > 0).length === 8);
+    const metrics = await page.evaluate(() => (window as unknown as {metrics:{peak:number;active:number;total:number;attempts:Record<string,number>;waits:number[]}}).metrics);
+    expect(metrics.peak).toBe(4); expect(metrics.active).toBe(0); expect(metrics.total).toBe(16);
+    expect(Object.values(metrics.attempts)).toEqual(Array(8).fill(2));
+    expect(metrics.waits).toHaveLength(8); expect(Math.min(...metrics.waits)).toBeGreaterThanOrEqual(990);
+    expect(await page.locator('body').innerText()).not.toContain('too many images loading');
+    expect(errors).toEqual([]);
+  } finally { await browser?.close(); await server.close(); }
+}, 20000);

--- a/web/src/artifact-queue.test.ts
+++ b/web/src/artifact-queue.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { imageArtifact } from './imageJobs';
+import type { Transport } from './transport';
+
+const cooldownMessage = 'too many images loading at once; retry in a second';
+const limited = (seconds = 1) => Response.json({ error: { code: 'concurrency_limited', message: cooldownMessage } }, { status: 429, headers: { 'Retry-After': String(seconds) } });
+afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+it('honors Retry-After and exposes the gallery message only after two retries', async () => {
+  vi.useFakeTimers(); const fetch = vi.fn(async () => limited(2));
+  let settled = false;
+  const read = imageArtifact({ fetch } as unknown as Transport, 'key', 'image', new AbortController().signal);
+  const failed = expect(read.finally(() => { settled = true; })).rejects.toThrow(cooldownMessage);
+  await vi.advanceTimersByTimeAsync(1999); expect(fetch).toHaveBeenCalledTimes(1); expect(settled).toBe(false);
+  await vi.advanceTimersByTimeAsync(1); expect(fetch).toHaveBeenCalledTimes(2); expect(settled).toBe(false);
+  await vi.advanceTimersByTimeAsync(2000); await failed; expect(fetch).toHaveBeenCalledTimes(3);
+  await vi.advanceTimersByTimeAsync(10000); expect(fetch).toHaveBeenCalledTimes(3);
+});
+
+it('removes an aborted queued tile without starting it or blocking later work', async () => {
+  vi.useFakeTimers(); let block = true;
+  const releases: (() => void)[] = [], started: string[] = [];
+  const transport = { fetch: async (path: string) => {
+    started.push(path); if (block) await new Promise<void>((resolve) => releases.push(resolve));
+    return new Response(new Uint8Array([1]), { headers: { 'Content-Type': 'image/png' } });
+  } } as unknown as Transport;
+  const active = Array.from({ length: 4 }, (_, i) => imageArtifact(transport, 'key', `held-${i}`, new AbortController().signal));
+  const ac = new AbortController(), queued = imageArtifact(transport, 'key', 'cancelled', ac.signal);
+  const cancelled = expect(queued).rejects.toMatchObject({ name: 'AbortError' });
+  await vi.advanceTimersByTimeAsync(0); expect(started).toHaveLength(4);
+  ac.abort(); await cancelled; block = false; releases.forEach((release) => release()); await Promise.all(active);
+  await imageArtifact(transport, 'key', 'next', new AbortController().signal);
+  expect(started).toHaveLength(5); expect(started.some((path) => path.endsWith('/cancelled'))).toBe(false);
+});
+
+it('cancels a retry cooldown without another host request', async () => {
+  vi.useFakeTimers(); const fetch = vi.fn(async () => limited()), ac = new AbortController();
+  const read = imageArtifact({ fetch } as unknown as Transport, 'key', 'image', ac.signal);
+  const cancelled = expect(read).rejects.toMatchObject({ name: 'AbortError' });
+  await vi.advanceTimersByTimeAsync(0); expect(fetch).toHaveBeenCalledTimes(1);
+  ac.abort(); await cancelled; await vi.advanceTimersByTimeAsync(5000); expect(fetch).toHaveBeenCalledTimes(1);
+});
+
+it('starts the thirty-second read deadline after dequeue, so later tiles can finish', async () => {
+  vi.useFakeTimers(); let calls = 0;
+  const transport = { fetch: (_path: string, init: RequestInit) => new Promise<Response>((resolve, reject) => {
+    calls++; const signal = init.signal!;
+    const abort = () => { clearTimeout(timer); reject(signal.reason); };
+    const timer = setTimeout(() => { signal.removeEventListener('abort', abort); resolve(new Response(new Uint8Array([1]), { headers: { 'Content-Type': 'image/png' } })); }, 20000);
+    signal.addEventListener('abort', abort, { once: true });
+  }) } as unknown as Transport;
+  const reads = Array.from({ length: 8 }, (_, i) => imageArtifact(transport, 'key', String(i), new AbortController().signal));
+  await vi.advanceTimersByTimeAsync(0); expect(calls).toBe(4);
+  await vi.advanceTimersByTimeAsync(20000); expect(calls).toBe(8);
+  await vi.advanceTimersByTimeAsync(20000); expect(await Promise.all(reads)).toHaveLength(8);
+});

--- a/web/src/imageJobs.ts
+++ b/web/src/imageJobs.ts
@@ -1,7 +1,7 @@
 /** One image per non-empty paragraph; lines inside a paragraph stay together. */
 export function imagePrompts(text: string): string[] { return text.trim().split(/\r?\n[\t ]*\r?\n(?:[\t ]*\r?\n)*/).map((p) => p.trim()).filter(Boolean); }
 
-import { call, type RunRecord } from './api';
+import { call, GatewayError, timeoutSignal, type RunRecord } from './api';
 import type { Transport } from './transport';
 import type { Conversation, RunItem } from './storage';
 export interface ImageJob extends RunRecord {
@@ -40,8 +40,43 @@ export function mergeImageJobs(convs: Conversation[], jobs: ImageJob[], keyId: s
   }
   return next;
 }
-/** Never follow the host-supplied URL; the authenticated route is fixed and key scoped. */
+// Shared by the sheet, chat rows and Save; a slot covers the complete response body.
+let artifactReads = 0;
+const artifactWaiting: (() => void)[] = [];
+function artifactSlot(signal: AbortSignal): Promise<() => void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) { reject(signal.reason); return; }
+    const start = () => {
+      signal.removeEventListener('abort', abort); artifactReads++;
+      resolve(() => { artifactReads--; artifactWaiting.shift()?.(); });
+    };
+    const abort = () => { const i = artifactWaiting.indexOf(start); if (i >= 0) artifactWaiting.splice(i, 1); reject(signal.reason); };
+    if (artifactReads < 4) start();
+    else { artifactWaiting.push(start); signal.addEventListener('abort', abort, { once: true }); }
+  });
+}
+function artifactCooldown(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) { reject(signal.reason); return; }
+    const abort = () => { clearTimeout(timer); signal.removeEventListener('abort', abort); reject(signal.reason); };
+    const timer = setTimeout(() => { signal.removeEventListener('abort', abort); resolve(); }, ms);
+    signal.addEventListener('abort', abort, { once: true });
+  });
+}
+/** Only reads retry: two retries after the host's cooldown, never a mutation replay. */
 export async function imageArtifact(t: Transport, secret: string, id: string, signal: AbortSignal, download = false): Promise<Blob> {
+  for (let attempt = 0; ; attempt++) {
+    const release = await artifactSlot(signal); let wait: number;
+    try { return await readImageArtifact(t, secret, id, timeoutSignal(30000, signal), download); }
+    catch (error) {
+      if (signal.aborted || !(error instanceof GatewayError) || error.status !== 429 || attempt === 2) throw error;
+      wait = (error.retryAfterS ?? 1) * 1000;
+    } finally { release(); }
+    await artifactCooldown(wait, signal);
+  }
+}
+/** Never follow the host-supplied URL; the authenticated route is fixed and key scoped. */
+async function readImageArtifact(t: Transport, secret: string, id: string, signal: AbortSignal, download: boolean): Promise<Blob> {
   const response = await call(t, secret, `/v1/images/outputs/${encodeURIComponent(id)}${download ? '?download=1' : ''}`, { signal });
   const mime = response.headers.get('content-type')?.split(';')[0];
   if (!['image/png','image/jpeg'].includes(mime ?? '') || !response.body) { await response.body?.cancel(); throw new Error('Invalid image output'); }

--- a/web/src/ui/ImageJobs.tsx
+++ b/web/src/ui/ImageJobs.tsx
@@ -1,6 +1,6 @@
 import { hostImages } from '../api';
 import { useEffect, useState } from 'react';
-import { GatewayError, timeoutSignal } from '../api';
+import { GatewayError } from '../api';
 import { imageArtifact, imageElapsed, imageGone, type ImageJob } from '../imageJobs';
 import { appLanguage, tr } from '../i18n/text';
 import { bytesLabel } from '../images';
@@ -14,7 +14,7 @@ function useOutput(job: ImageJob | undefined, live: Live) {
   useEffect(() => {
     if (!job || !available || live.offline) return;
     const ac = new AbortController(); let url = '';
-    void imageArtifact(live.transport, live.secret, job.id, timeoutSignal(30000, ac.signal)).then((blob) => {
+    void imageArtifact(live.transport, live.secret, job.id, ac.signal).then((blob) => {
       if (ac.signal.aborted) return;
       url = URL.createObjectURL(blob); setLoaded({ id: job.id, url, gone: false, error: '' });
     }).catch((error) => { if (!ac.signal.aborted) setLoaded({ id: job.id, url: '', gone: error instanceof GatewayError && error.status === 404, error: String(error) }); });
@@ -23,7 +23,7 @@ function useOutput(job: ImageJob | undefined, live: Live) {
   return loaded.id === job?.id && available ? loaded : { url: '', gone: false, error: '' };
 }
 export async function saveImage(job: ImageJob, live: Live) {
-  const blob = await imageArtifact(live.transport, live.secret, job.id, timeoutSignal(30000), true), url = URL.createObjectURL(blob);
+  const blob = await imageArtifact(live.transport, live.secret, job.id, new AbortController().signal, true), url = URL.createObjectURL(blob);
   const a = document.createElement('a'); a.href = url; a.download = `${job.id}.${blob.type === 'image/jpeg' ? 'jpg' : 'png'}`; a.click();
   setTimeout(() => URL.revokeObjectURL(url), 1000);
 }


### PR DESCRIPTION
144c queues image artifact reads four-wide across the Images sheet, chat rows and Save. Each slot covers the complete response body. A 429 releases its slot before waiting for Retry-After (1 s fallback), then retries at most twice; only the final failure reaches the existing gallery error display. Aborting removes queued work or cancels the cooldown/read. The existing 30 s deadline starts after dequeue for each attempt, so a large gallery does not expire while waiting locally.

Core proof: `cd web && pnpm test src/artifact-gallery.test.ts` — **1 passed / 0 failed / 0 skipped**. The fixture renders the real ImagesSheet with eight tiles, returns one 429 per tile, and holds successful response bodies open. It verifies **peak 4 active reads, 16 total requests, all 8 decoded images rendered, Retry-After observed, and no premature gallery error**. The fixture is self-contained in `web/src/artifact-gallery.test.ts`; four unit fixtures cover retry exhaustion, queued/cooldown abort and later tiles completing after 40 s of total queue time.

Validation: typecheck and lint clean; full web suite **473 passed / 0 failed / 0 skipped**; `make check` **CHECK OK**. Logs `/tmp/infercat-144c-web-tests.log`, `/tmp/infercat-144c-check.log`, `/tmp/infercat-144c-final-gallery.log`.

Freeze: L2, size 0, one commit on `ticket/144c-artifact-queue`. Base `923e2edc209ff16aea348ed6a3bcd05a16043cbb`; tip `f96cb59b06a682829db3092b84871dbe4bf657bc`. Patch SHA-256 (`git diff --binary BASE TIP`): `c4902b3cd5e61bd03e23e2cd03f728963e613d951ce94a14c0e19f6b5b54c71c`.

Accounting: source **+40/-5 = 45 against ~80**; tests **+120/-0 = 120**; total **+160/-5 = 165**, four web files. **0 new concepts, flags, fields or dependencies.** 159 remains untouched and frozen at `93f58b6`. 144c held unchanged for review.
