### PR TITLE
163: Reduce CI fixture cost without dropping proofs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# Every push and PR: the Go checks, the web checks, the notices gate, and a full release dry run —
+# Every push: the Go checks, the web checks, the notices gate, and a full release dry run —
 # all from this fresh checkout, which is the "green from nothing" law (docs/PRINCIPLES.md). Nothing here
 # publishes; release.yml is the only workflow that can, and only on a tag.
 name: CI
@@ -6,7 +6,10 @@ name: CI
 on:
   push:
     branches: ['**']
-  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -48,7 +51,7 @@ jobs:
       - name: Playwright version
         id: playwright
         run: |
-          pnpm --dir web install --frozen-lockfile
+          make web-deps
           node -p '"version=" + require("./web/node_modules/playwright/package.json").version' >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
@@ -61,24 +64,8 @@ jobs:
       - name: Playwright system dependencies
         run: pnpm --dir web exec playwright install-deps chromium
 
-      - name: Go and Worker — build, vet, test
-        run: |
-          go build ./...
-          make check
-
-      - name: Web — install, typecheck, test, lint
-        working-directory: web
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm typecheck
-          pnpm test
-          pnpm lint
-
       - name: go-licenses
-        run: go install github.com/google/go-licenses@latest
-
-      - name: Third-party notices are current
-        run: make notices-check
+        run: go install github.com/google/go-licenses@v1.6.0
 
       - uses: goreleaser/goreleaser-action@v7
         with:
@@ -87,8 +74,12 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: Release dry run (every artifact, nothing published)
-        run: make release-dry
+      - name: Check and release dry run (every proof once, nothing published)
+        run: |
+          go build ./...
+          # The Playwright-version step already installed the locked workspace.
+          # One make graph shares all other prerequisites; no proof is skipped.
+          make -o web-deps check release-dry
 
       - name: Every artifact has a checksum
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export VITE_APP_VERSION := $(PRODUCT_VERSION)
 # image URL in index.html, which must be absolute to be picked up.
 export VITE_WEB_URL := $(shell sed -n 's/^[[:space:]]*WebURL[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' internal/product/product.go)
 
-.PHONY: build test vet wasm web web-test web-lint check clean release-dry notices notices-check brand launch-check deploy-web
+.PHONY: console-deps web-deps web-typecheck web-browser build test vet wasm web web-test web-lint check clean release-dry notices notices-check brand launch-check deploy-web
 
 build:
 	go build -o bin/infercat ./cmd/infercat
@@ -37,14 +37,26 @@ check: console-check vet test client-check bridge-check web-lint host-compat
 wasm:
 	sh web/wasm/build.sh
 
-web: console-check wasm
-	cd web && pnpm install --frozen-lockfile && pnpm typecheck && pnpm build
+console-deps:
+	cd console && pnpm install --frozen-lockfile
 
-web-test:
+web-deps:
+	cd web && pnpm install --frozen-lockfile
+
+web-typecheck: web-deps
+	cd web && pnpm typecheck
+
+web-browser: web-deps
+	cd web && pnpm exec playwright install chromium
+
+web: console-check wasm web-typecheck
+	cd web && pnpm build
+
+web-test: web-browser
 	cd web && pnpm test
 
-web-lint:
-	cd web && pnpm install --frozen-lockfile && pnpm lint
+web-lint: web-deps
+	cd web && pnpm lint
 
 # The icon set, the social-card image and GitHub's social preview, rendered from the SVG mark and
 # the real connect screen (web/dev/brand.mjs). Re-run after a rename or a new mark; commit the PNGs.
@@ -103,26 +115,23 @@ bridge-check:
 	cd bridge && npm ci --legacy-peer-deps && npm run typecheck && npm test
 
 .PHONY: client-check
-client-check:
+client-check: web-deps
 	test "$(PRODUCT_VERSION)" = "$$(node -p "require('./packages/client/package.json').version")"
-	cd web && pnpm install --frozen-lockfile
 	cd web && pnpm --filter @infercat/client build && pnpm --filter @infercat/client typecheck && pnpm --filter @infercat/client lint && pnpm --filter @infercat/client test
 
 .PHONY: console-check
-console-check:
-	cd console && pnpm install --frozen-lockfile && pnpm typecheck && pnpm lint && pnpm test && pnpm check-dist
+console-check: console-deps
+	cd console && pnpm typecheck && pnpm lint && pnpm test && pnpm check-dist
 
 .PHONY: console-build
-console-build:
-	cd console && pnpm install --frozen-lockfile && pnpm build
+console-build: console-deps
+	cd console && pnpm build
 
 # Shipped /me shapes must render Connect → Chat; install the pinned browser on clean machines.
 .PHONY: host-compat
-host-compat: web-lint wasm
-	cd web && pnpm typecheck && pnpm exec vitest run src/host-compat.test.ts src/console-compat.test.ts src/admin-route.test.ts src/voice.test.ts src/voice-ui.test.ts
-	cd web && pnpm exec playwright install chromium
+host-compat: web-lint web-test web
 	cd web && pnpm exec node dev/host-compat.mjs
-	cd web && pnpm build && pnpm exec node dev/console-chunk-check.mjs
+	cd web && pnpm exec node dev/console-chunk-check.mjs
 
 # Opt-in real iOS proof; requires Xcode/runtime and an owned loopback engine.
 .PHONY: ios-proof

--- a/internal/profile/install_test.go
+++ b/internal/profile/install_test.go
@@ -32,7 +32,15 @@ func TestMain(m *testing.M) {
 			time.Sleep(500 * time.Millisecond)
 		}
 		os.WriteFile(os.Getenv("PROFILE_PID"), []byte(strconv.Itoa(os.Getpid())), 0600)
-		http.ListenAndServe("127.0.0.1:"+os.Args[2], http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		listener, err := net.Listen("tcp4", "127.0.0.1:"+os.Args[2])
+		if err != nil {
+			os.Exit(1)
+		}
+		if path := os.Getenv("PROFILE_PORT"); path != "" {
+			os.WriteFile(path+".tmp", []byte(strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)), 0600)
+			os.Rename(path+".tmp", path)
+		}
+		http.Serve(listener, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if os.Getenv("PROFILE_STALL") == "1" {
 				<-r.Context().Done()
 				return

--- a/internal/profile/runtime.go
+++ b/internal/profile/runtime.go
@@ -25,6 +25,7 @@ type Runtime struct {
 	cancel  context.CancelFunc
 }
 type managed struct {
+	testPort       func(reset bool) int // Test-only dynamic listener; nil for installed engines.
 	mu             sync.Mutex
 	ctx            context.Context
 	member         Member
@@ -203,9 +204,15 @@ func (m *managed) startLocked() {
 		if e == nil {
 			var cmd, env []string
 			var work string
-			cmd, env, work, e = Materialize(m.profile, m.member, m.installed, m.installation.Artifacts, m.dir)
+			m.mu.Lock()
+			member := m.member
+			if m.testPort != nil {
+				member.Port = m.testPort(true)
+			}
+			m.mu.Unlock()
+			cmd, env, work, e = Materialize(m.profile, member, m.installed, m.installation.Artifacts, m.dir)
 			if e == nil {
-				p, e = supervise.Start(cmd, env, work, strings.TrimPrefix(m.member.URL(), "http://"))
+				p, e = supervise.Start(cmd, env, work, strings.TrimPrefix(member.URL(), "http://"))
 			}
 		}
 		if e == nil {
@@ -236,7 +243,15 @@ func (m *managed) startLocked() {
 	}()
 }
 func (m *managed) probe(ctx context.Context) error {
+	m.mu.Lock()
 	member := m.member
+	if m.testPort != nil {
+		member.Port = m.testPort(false)
+		if member.Port > 0 && member.Port != m.member.Port {
+			m.member.Port = member.Port
+		}
+	}
+	m.mu.Unlock()
 	member.Class = "probe"
 	v := Check(ctx, member, nil, nil)
 	if v.Err != nil {

--- a/internal/profile/runtime_test.go
+++ b/internal/profile/runtime_test.go
@@ -36,9 +36,7 @@ func runtimeFixture(t *testing.T, policy string, classes ...string) (*Runtime, *
 	if len(classes) > 0 {
 		m.Class = classes[0]
 	}
-	l, _ := net.Listen("tcp4", "127.0.0.1:0")
-	m.Port = l.Addr().(*net.TCPAddr).Port
-	l.Close()
+	m.Port = 0
 	m.Artifact = "engine"
 	m.Command = []string{"engine", "{port}", "{model_name}"}
 	m.Policy = Policy{Kind: policy}
@@ -46,7 +44,8 @@ func runtimeFixture(t *testing.T, policy string, classes ...string) (*Runtime, *
 		m.Policy.IdleSeconds = 1
 	}
 	m.Model.Assets = []Asset{pin([]byte("model"), "https://example.test/model")}
-	m.Env = map[string]string{"PROFILE_PID": filepath.Join(root, "pid")}
+	portFile := filepath.Join(root, "port")
+	m.Env = map[string]string{"PROFILE_PID": filepath.Join(root, "pid"), "PROFILE_PORT": portFile}
 	p.Artifacts = []Artifact{{Asset: Asset{ID: "engine"}, Executable: "engine"}}
 	im := InstalledMember{ID: m.ID, Paths: map[string]string{"test": model}}
 	bh, _ := fileHash(bin)
@@ -54,6 +53,15 @@ func runtimeFixture(t *testing.T, policy string, classes ...string) (*Runtime, *
 	in := Installation{Artifacts: map[string]string{"engine": art}, Files: map[string]string{bin: bh, model: mh}, Links: map[string]string{}}
 	ctx, cancel := context.WithCancel(context.Background())
 	v := &managed{ctx: ctx, member: m, installed: im, installation: in, profile: p, dir: root, status: MemberStatus{ID: m.ID, State: "dormant"}, done: make(chan struct{})}
+	v.testPort = func(reset bool) int {
+		if reset {
+			os.Remove(portFile)
+			return 0
+		}
+		raw, _ := os.ReadFile(portFile)
+		port, _ := strconv.Atoi(string(raw))
+		return port
+	}
 	r := &Runtime{members: map[string]*managed{m.Class: v}, cancel: cancel}
 	go v.loop()
 	t.Cleanup(r.Close)
@@ -351,6 +359,9 @@ func TestManagedFailedStartDoesNotRetryWithoutLease(t *testing.T) {
 		t.Fatal(e)
 	}
 	defer busy.Close()
+	m.mu.Lock()
+	m.member.Port, m.testPort = busy.Addr().(*net.TCPAddr).Port, nil
+	m.mu.Unlock()
 	if release, e := r.Acquire(context.Background(), "image"); e == nil {
 		release()
 		t.Fatal("occupied port accepted")

--- a/internal/run/corrections154_test.go
+++ b/internal/run/corrections154_test.go
@@ -15,17 +15,29 @@ import (
 // Write a valid legacy snapshot that predates the reserved terminal headroom.
 func ceilingFixture(t *testing.T, s *Store, r Run, headroom int) {
 	t.Helper()
+	ceilingFixtureAt(t, s, r, headroom, 1<<20)
+}
+func newCeilingStore(dir string, ceiling int) (*Store, error) {
+	s, err := NewStore(dir)
+	if err == nil {
+		s.maxStored = ceiling
+	}
+	return s, err
+}
+func ceilingFixtureAt(t *testing.T, s *Store, r Run, headroom, ceiling int) {
+	t.Helper()
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.maxStored = ceiling
 	v := clone(s.data[r.KeyID])
 	f := v.Runs[r.ID]
 	f.Input = json.RawMessage(`""`)
 	v.Runs[r.ID] = f
 	raw, _ := json.Marshal(v)
-	f.Input = json.RawMessage(`"` + strings.Repeat("x", MaxStored-headroom-len(raw)) + `"`)
+	f.Input = json.RawMessage(`"` + strings.Repeat("x", s.maxStored-headroom-len(raw)) + `"`)
 	v.Runs[r.ID] = f
 	raw, _ = json.Marshal(v)
-	if len(raw) != MaxStored-headroom {
+	if len(raw) != s.maxStored-headroom {
 		t.Fatal(len(raw))
 	}
 	if err := atomicWrite(filepath.Join(s.root, r.KeyID, "state.json"), raw); err != nil {
@@ -78,7 +90,7 @@ func Test154TerminalBudgetFallbackAndLazyRecovery(t *testing.T) {
 	if err != nil || got.State != Done || !strings.Contains(string(got.Output), "output not retained: budget") {
 		t.Fatal(got.State, err)
 	}
-	reopened, err := NewStore(filepath.Dir(s.root))
+	reopened, err := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +110,7 @@ func Test154TerminalBudgetFallbackAndLazyRecovery(t *testing.T) {
 	s2 := store(t)
 	live := create(t, s2, "k_live")
 	ceilingFixture(t, s2, live, 151)
-	reopened, _ = NewStore(filepath.Dir(s2.root))
+	reopened, _ = newCeilingStore(filepath.Dir(s2.root), s2.maxStored)
 	m3, err := New(reopened, nil, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -308,4 +320,28 @@ func Test154CancelAcquisitionRaceUsesCommittedState(t *testing.T) {
 			t.Fatal("cancel saw running but killed generating attempt")
 		}
 	}
+}
+
+// Keep one real-size allocation/load boundary; the semantic fixtures above use
+// 1 MiB but keep the same byte-exact headroom and terminal-reserve assertions.
+func TestProductionStorageCeiling(t *testing.T) {
+	s := store(t)
+	if s.maxStored != 64<<20 {
+		t.Fatal("production ceiling changed", s.maxStored)
+	}
+	r := create(t, s, "real_ceiling")
+	s.change(r.KeyID, r.ID, func(v *Run) error { v.State = Done; return nil })
+	ceilingFixtureAt(t, s, r, MaxLiveKey*terminalBound, MaxStored)
+	if _, err := s.Create(r.KeyID, "test", "interactive", json.RawMessage(`{}`)); !errors.Is(err, ErrLimit) {
+		t.Fatal("real-size admission did not refuse", err)
+	}
+	fresh, err := NewStore(filepath.Dir(s.root)) // Deliberately no injected ceiling on restart.
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := fresh.Get(r.KeyID, r.ID)
+	if err != nil || got.State != Done || len(got.Input) != len(s.data[r.KeyID].Runs[r.ID].Input) {
+		t.Fatal("real-size boundary did not reload intact", got.State, err)
+	}
+	t.Logf("production boundary: ceiling=%d bytes=%d", fresh.maxStored, fresh.data[r.KeyID].encodedBytes)
 }

--- a/internal/run/exception157_test.go
+++ b/internal/run/exception157_test.go
@@ -58,7 +58,7 @@ func Test157V2ExceptionPerRunSurvivesRestart(t *testing.T) {
 			break
 		}
 		if i == 3 {
-			reopened, e := NewStore(filepath.Dir(s.root))
+			reopened, e := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 			if e != nil {
 				t.Fatal(e)
 			}
@@ -134,7 +134,7 @@ func Test157V2AbsoluteCapTrimsReplayNotEvidence(t *testing.T) {
 	if _, _, err = s.ReadImage("key", r.ID); err != nil {
 		t.Fatal(err)
 	}
-	if logs == 0 || s.data["key"].encodedBytes > MaxStored+MaxRuns*terminalBound {
+	if logs == 0 || s.data["key"].encodedBytes > s.maxStored+MaxRuns*terminalBound {
 		t.Fatal("unlogged or oversized")
 	}
 	select {
@@ -153,7 +153,7 @@ func Test157V2AbsoluteCapTrimsReplayNotEvidence(t *testing.T) {
 	if len(replay) != 1 || !replay[0].Reset {
 		t.Fatal("trim did not reset old cursor", replay)
 	}
-	reopened, err := NewStore(filepath.Dir(s.root))
+	reopened, err := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func Test157V2FullRecoveryContinuesAfterMinimalTerminal(t *testing.T) {
 	filler, a, b := create(t, s, "key"), create(t, s, "key"), create(t, s, "key")
 	s.change(filler.KeyID, filler.ID, func(v *Run) error { v.State = Done; return nil })
 	ceilingFixture(t, s, filler, -MaxRuns*terminalBound)
-	reopened, err := NewStore(filepath.Dir(s.root))
+	reopened, err := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/run/retained.go
+++ b/internal/run/retained.go
@@ -51,7 +51,7 @@ func (s *Store) Admit(key, rid string, bytes int) (func(), error) {
 	if terminal(r.State) || r.CancelRequested {
 		return nil, ErrConflict
 	}
-	if bytes <= 0 || bytes > MaxStored-MaxLiveKey*terminalBound {
+	if bytes <= 0 || bytes > s.maxStored-MaxLiveKey*terminalBound {
 		return nil, ErrLimit
 	}
 	if s.reserved == nil {
@@ -64,7 +64,7 @@ func (s *Store) Admit(key, rid string, bytes int) (func(), error) {
 		return nil, ErrConflict
 	}
 	raw, _ := json.Marshal(v)
-	if len(raw)+s.reservedBytes(key)+bytes > MaxStored-MaxLiveKey*4096 {
+	if len(raw)+s.reservedBytes(key)+bytes > s.maxStored-MaxLiveKey*4096 {
 		return nil, ErrLimit
 	}
 	lease := &reservation{bytes: bytes}
@@ -99,7 +99,7 @@ func (s *Store) retainedBudget(key string, next *snapshot, rid string, size int)
 			credit = min(lease.bytes, max(0, size-len(old)))
 		}
 	}
-	if size+s.reservedBytes(key)-credit > MaxStored-MaxLiveKey*terminalBound {
+	if size+s.reservedBytes(key)-credit > s.maxStored-MaxLiveKey*terminalBound {
 		return nil, ErrLimit
 	}
 	if lease != nil {

--- a/internal/run/review157_2_test.go
+++ b/internal/run/review157_2_test.go
@@ -29,7 +29,7 @@ func Test157ExpiryAboveCeilingAndRestart(t *testing.T) {
 	v.Runs[small.ID] = r
 	s.mu.Unlock()
 	ceilingFixture(t, s, filler, MaxLiveKey*terminalBound-2048)
-	reopened, err := NewStore(filepath.Dir(s.root))
+	reopened, err := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,10 +51,10 @@ func Test157ExpiryAboveCeilingAndRestart(t *testing.T) {
 	reopened.mu.Lock()
 	raw, _ := json.Marshal(reopened.data[filler.KeyID])
 	reopened.mu.Unlock()
-	if len(raw) <= MaxStored-MaxLiveKey*terminalBound {
+	if len(raw) <= s.maxStored-MaxLiveKey*terminalBound {
 		t.Fatal("fixture fell below ordinary ceiling")
 	}
-	again, err := NewStore(filepath.Dir(s.root))
+	again, err := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/run/review157_v4_test.go
+++ b/internal/run/review157_v4_test.go
@@ -117,15 +117,13 @@ func Test157V4CeilingEnumerationCost(t *testing.T) {
 	s.mu.Lock()
 	s.releaseIdle()
 	s.mu.Unlock()
-	for range 3 {
-		began := time.Now()
-		rows, err := s.List("")
-		elapsed := time.Since(began)
-		if err != nil || len(rows) != 1 || len(s.data) != 0 {
-			t.Fatal(len(rows), len(s.data), err)
-		}
-		t.Logf("nonresident ceiling key: bytes=%d elapsed=%v", MaxStored-MaxLiveKey*terminalBound, elapsed)
+	began := time.Now()
+	rows, err := s.List("")
+	elapsed := time.Since(began)
+	if err != nil || len(rows) != 1 || len(s.data) != 0 {
+		t.Fatal(len(rows), len(s.data), err)
 	}
+	t.Logf("nonresident ceiling key: bytes=%d elapsed=%v", s.maxStored-MaxLiveKey*terminalBound, elapsed)
 }
 
 func Test157V4ExpiredJoinUsesTerminalReserve(t *testing.T) {
@@ -217,7 +215,7 @@ func Test157V4LegacyFullKeyFailsClosedWithoutChangingBytes(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			fresh, err := NewStore(filepath.Dir(s.root))
+			fresh, err := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -236,7 +234,7 @@ func Test157V4LegacyFullKeyFailsClosedWithoutChangingBytes(t *testing.T) {
 			if _, err := fresh.Get("legacy", live.ID); !errors.Is(err, ErrNeedsAttention) {
 				t.Fatal("second load admitted legacy key", err)
 			}
-			restarted, _ := NewStore(filepath.Dir(s.root))
+			restarted, _ := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 			if _, err := restarted.Get("legacy", live.ID); !errors.Is(err, ErrNeedsAttention) {
 				t.Fatal("mark not re-derived", err)
 			}

--- a/internal/run/review157_v5_test.go
+++ b/internal/run/review157_v5_test.go
@@ -31,7 +31,7 @@ func Test157V5RecoveryRetriesAfterRefusedWrite(t *testing.T) {
 	if err != nil || got.State != Failed || !s.recovered[r.KeyID] || writes != 2 {
 		t.Fatal(got.State, err, writes)
 	}
-	fresh, _ := NewStore(filepath.Dir(s.root))
+	fresh, _ := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 	got, err = fresh.Get(r.KeyID, r.ID)
 	if err != nil || got.State != Failed {
 		t.Fatal("recovery not durable", got.State, err)
@@ -59,7 +59,7 @@ func Test157V5TerminalReserveOrReplayAllowsRecovery(t *testing.T) {
 			s.data["key"].ExceptionBytes = map[string]int{live.ID: used}
 			s.mu.Unlock()
 			ceilingFixture(t, s, filler, MaxLiveKey*terminalBound)
-			fresh, err := NewStore(filepath.Dir(s.root))
+			fresh, err := newCeilingStore(filepath.Dir(s.root), s.maxStored)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -38,6 +38,7 @@ type Store struct {
 	write           func(string, []byte) error
 	reserved        map[string]map[string]*reservation
 	imageBudget     int
+	maxStored       int // Test-injectable before use; production always starts at MaxStored.
 	imageCleanup    map[string]bool
 	imageOrphans    map[string]bool
 	emptyImageStamp map[string]time.Time
@@ -62,7 +63,7 @@ func NewStore(dataDir string) (*Store, error) {
 	if dataDir == "" {
 		return nil, ErrInvalid
 	}
-	s := &Store{root: filepath.Join(dataDir, "runs"), data: map[string]*snapshot{}, broken: map[string]error{}, subs: map[string]map[chan Event]bool{}, now: time.Now, write: atomicWrite, known: map[string]bool{}, accessed: map[string]time.Time{}, recovered: map[string]bool{}}
+	s := &Store{maxStored: MaxStored, root: filepath.Join(dataDir, "runs"), data: map[string]*snapshot{}, broken: map[string]error{}, subs: map[string]map[chan Event]bool{}, now: time.Now, write: atomicWrite, known: map[string]bool{}, accessed: map[string]time.Time{}, recovered: map[string]bool{}}
 	if err := privateDir(s.root); err != nil {
 		return nil, err
 	}
@@ -146,12 +147,12 @@ func (s *Store) load(key string) (*snapshot, error) {
 		if e != nil {
 			return nil, e
 		}
-		raw, e := io.ReadAll(io.LimitReader(f, MaxStored+MaxRuns*terminalBound+1))
+		raw, e := io.ReadAll(io.LimitReader(f, int64(s.maxStored+MaxRuns*terminalBound+1)))
 		f.Close()
 		if e != nil {
 			return nil, e
 		}
-		if len(raw) > MaxStored+MaxRuns*terminalBound {
+		if len(raw) > s.maxStored+MaxRuns*terminalBound {
 			return nil, ErrLimit
 		}
 		v.encodedBytes = len(raw)
@@ -208,7 +209,7 @@ func (s *Store) load(key string) (*snapshot, error) {
 		}
 		probe.Runs[rid] = r
 		raw, _ := json.Marshal(&probe)
-		if used+max(0, len(raw)-v.encodedBytes) > terminalBound || len(raw) > MaxStored+MaxRuns*terminalBound {
+		if used+max(0, len(raw)-v.encodedBytes) > terminalBound || len(raw) > s.maxStored+MaxRuns*terminalBound {
 			s.log("runs for key %s fail closed: operator reclamation required; snapshot bytes preserved", key)
 			s.markBroken(key, ErrNeedsAttention)
 			return nil, ErrNeedsAttention
@@ -320,7 +321,7 @@ func (s *Store) commitFor(key string, v *snapshot, event *Event, rid string) err
 		if !terminal(r.State) {
 			limit -= 512
 		}
-		if used+max(0, len(raw)-old.encodedBytes) > limit || len(raw) > MaxStored+MaxRuns*terminalBound {
+		if used+max(0, len(raw)-old.encodedBytes) > limit || len(raw) > s.maxStored+MaxRuns*terminalBound {
 			r.State, r.Reason = Failed, "storage exhausted"
 			r.Expires = r.Updated.Add(Retention)
 			v.Runs[rid] = r
@@ -342,14 +343,14 @@ func (s *Store) commitFor(key string, v *snapshot, event *Event, rid string) err
 			}
 			raw, _ = json.Marshal(v)
 			// Replay is disposable; attempts, usage and captured outputs are not.
-			for (used+max(0, len(raw)-old.encodedBytes) > terminalBound || len(raw) > MaxStored+MaxRuns*terminalBound) && len(v.Events) > 0 {
+			for (used+max(0, len(raw)-old.encodedBytes) > terminalBound || len(raw) > s.maxStored+MaxRuns*terminalBound) && len(v.Events) > 0 {
 				v.Events = v.Events[1:]
 				raw, _ = json.Marshal(v)
 			}
 			s.log("run %s/%s lifecycle refused: storage exhausted", key, rid)
 		}
 		charge := max(0, len(raw)-old.encodedBytes)
-		if used+charge <= terminalBound && len(raw) <= MaxStored+MaxRuns*terminalBound {
+		if used+charge <= terminalBound && len(raw) <= s.maxStored+MaxRuns*terminalBound {
 			v.ExceptionBytes[rid] = used + charge
 			raw, _ = json.Marshal(v)
 			err, undo = nil, func() {}

--- a/internal/run/stored.go
+++ b/internal/run/stored.go
@@ -56,7 +56,7 @@ func (s *Store) stored(key string) (StoredData, error) {
 	if err != nil {
 		return StoredData{}, err
 	}
-	out := StoredData{KeyID: key, Cursor: fmt.Sprintf("%s:%d", v.Epoch, v.Seq), Kinds: map[string]StoredKind{}, Total: len(v.Runs), Bytes: v.encodedBytes, Budget: MaxStored - MaxLiveKey*terminalBound, Reserved: s.reservedBytes(key), ImageBudget: ImageBudget, Runs: []StoredRun{}}
+	out := StoredData{KeyID: key, Cursor: fmt.Sprintf("%s:%d", v.Epoch, v.Seq), Kinds: map[string]StoredKind{}, Total: len(v.Runs), Bytes: v.encodedBytes, Budget: s.maxStored - MaxLiveKey*terminalBound, Reserved: s.reservedBytes(key), ImageBudget: ImageBudget, Runs: []StoredRun{}}
 	expiry := func(at time.Time) {
 		if out.First == nil || at.Before(*out.First) {
 			t := at


### PR DESCRIPTION
Repeated 64 MiB boundary fixtures dominated CI. A private per-store test ceiling now runs the same byte-exact recovery/exception checks at 1 MiB, with one explicit production 64 MiB boundary/reload test retained. Every original run-store test still passes.

The Make graph shares verification prerequisites across `check` and `release-dry`; each package retains its own checks and frozen dependencies. CI is push-only, cancels superseded runs on the same ref, and pins go-licenses v1.6.0. Race, host compatibility, installer, notices, release artifacts and checksum proofs remain.

The faster suite exposed a parallel profile-fixture port race. The fixture child now binds :0 and atomically publishes the still-owned port through a private nil-by-default callback used by the existing readiness probe. Start/Guardian and installed-engine behavior stay unchanged; the deliberate occupied-port test keeps its normal refusal path. No new retry loop, skipped assertions, or serialized subtests.

Validation: final CI [34568986482](https://github.com/infercat/infercat/actions/runs/34568986482) green, including release artifacts/checksums. Whole-job time **12m41s → 7m19s**; CI run-store race **407.455 → 54.239 s**. Same-Mac race wall **248.19 → 42.44 s**, 153/0/0 versus 152/0/0 (one real-size test added). Local make check/notices pass; web 490/490; CI profile 21.037 s passed. The earlier candidate had two port-collision CI failures; the amended candidate passed its single run.

Freeze: base e852799; tip c4619ec. Counted source +91/-56 = **147** against revised ~140, including all callback/harness lines as directed; semantic tests +57/-23 = 80; total 227 changed lines, 13 files, no binary/generated changes. Patch SHA-256: `743a9294c611a6a1b1aa94e31f9bcd3d2d0c833c79a32e5c4e98c6e1cd5023c7`. Full freeze and evidence sent to the PM through Embassy.
