### PR TITLE
Retain published WASM runtime pairs in every site deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ check: console-check vet test client-check bridge-check web-lint host-compat
 	# host-compat built web/dist; run every no-invite launch assertion against that exact build.
 	@set -eu; launch_shots=$$(mktemp -d); trap 'rm -rf "$$launch_shots"' EXIT; \
 		cd web && env -u INVITE -u APP LAUNCH_SHOTS="$$launch_shots" pnpm launch-check
+	node --test hack/runtime-releases.test.mjs
 	sh hack/install_test.sh
 	@if command -v shellcheck >/dev/null 2>&1; then shellcheck -s sh hack/install.sh; else echo "shellcheck: skipped (not installed)"; fi
 	@echo "CHECK OK"
@@ -86,8 +87,7 @@ clean:
 deploy-web: web
 	test "$(PRODUCT_VERSION)" = "$$(node -p "require('./packages/client/package.json').version")"
 	rm -rf web/deploy && mkdir -p web/deploy && cp -R web/dist/. web/deploy/ && rm -f web/deploy/infercat.wasm
-	mkdir -p "web/deploy/v/$(PRODUCT_VERSION)"
-	cp web/deploy/infercat.wasm.gz web/deploy/wasm_exec.js "web/deploy/v/$(PRODUCT_VERSION)/"
+	node hack/runtime-releases.mjs web/deploy "$(PRODUCT_VERSION)"
 	cp hack/install.sh web/deploy/install.sh
 	cp docs/media/demo.mp4 docs/media/demo.zh.mp4 docs/media/demo-poster.png docs/media/demo-poster.zh.png web/deploy/
 	cp hosting/cloudflare/_headers hosting/cloudflare/_redirects hosting/cloudflare/_routes.json hosting/cloudflare/404.html hosting/cloudflare/derpmap.json web/deploy/ && cp -R hosting/cloudflare/functions web/deploy/

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -48,8 +48,20 @@ Attach `infercat.wasm.gz` and its matching Go `wasm_exec.js`, built from the tag
 1. Open the draft. Paste the `CHANGELOG.md` entry above the generated notes. Publish.
 2. `brew install infercat/tap/infercat` on a machine that has never had it; `infercat
    version` prints the tag.
-3. Deploy `web-0.1.0.zip` to the web app's host (F3) — the bundle is static; unzip at the site root.
-4. Bump `Version` in `product.go` and `version` in `packages/client/package.json` to the next
+3. Versioned client runtime (111): after publishing the matching `infercat.wasm.gz` and
+   `wasm_exec.js` release assets, append the version and each asset's SHA-256 to
+   `hosting/cloudflare/runtime-releases.json`. Retain every older entry. Obtain the digests with
+   `gh release view v<version> --repo infercat/infercat --json assets`; confirm the downloaded
+   bytes match. Commit the manifest before deploying.
+4. Run `make deploy-web` from the intended site commit. It fetches every listed release pair,
+   verifies its hashes, and stages `/v/<version>/` before invoking Pages. A missing asset, hash
+   mismatch, or unlisted stable current version stops publication. A dev build gets its own
+   `-dev` pair; it never replaces archived release bytes. Do not deploy the bare web zip to
+   production: that drops older clients' runtimes.
+5. After Pages reports success, run `node hack/runtime-releases.mjs --verify https://infercat.ai`.
+   Every listed pair (including 0.1.3 and 0.1.4) must return HTTP 200, public CORS, and its recorded
+   hash. Keep the output with the release evidence.
+6. Bump `Version` in `product.go` and `version` in `packages/client/package.json` to the next
    `-dev` (e.g. `0.1.1-dev`) on main.
 
 ## If the workflow is down

--- a/hack/runtime-releases.mjs
+++ b/hack/runtime-releases.mjs
@@ -1,0 +1,60 @@
+import { createHash } from 'node:crypto';
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+const files = ['infercat.wasm.gz', 'wasm_exec.js'];
+const manifestURL = new URL('../hosting/cloudflare/runtime-releases.json', import.meta.url);
+function validate(manifest) {
+  if (!Object.keys(manifest).length) throw new Error('No released runtimes listed');
+  for (const [version, pair] of Object.entries(manifest)) {
+    if (!/^\d+\.\d+\.\d+$/.test(version) || Object.keys(pair).sort().join() !== [...files].sort().join() || files.some(f => !/^[a-f0-9]{64}$/.test(pair[f]))) throw new Error(`Invalid runtime pair: ${version}`);
+  }
+}
+async function checked(url, hash, fetcher, cors = false) {
+  const response = await fetcher(url, { signal: AbortSignal.timeout(120000), ...(cors ? { headers: { Origin: 'https://client.example' } } : {}) });
+  if (response.status !== 200) throw new Error(`${url}: HTTP ${response.status}`);
+  if (cors && response.headers.get('access-control-allow-origin') !== '*') throw new Error(`${url}: missing public CORS`);
+  const bytes = Buffer.from(await response.arrayBuffer());
+  if (createHash('sha256').update(bytes).digest('hex') !== hash) throw new Error(`${url}: SHA-256 mismatch`);
+  return bytes;
+}
+/** Finish all downloads before changing /v; a failure stops make before publication. */
+export async function stageRuntimes(manifest, directory, current, fetcher = fetch) {
+  validate(manifest);
+  if (!/^\d+\.\d+\.\d+(?:-dev)?$/.test(current)) throw new Error('Invalid current version');
+  if (!current.endsWith('-dev') && !manifest[current]) throw new Error(`Released version ${current} missing from runtime manifest`);
+  await mkdir(directory, { recursive: true });
+  const temporary = await mkdtemp(join(directory, '.runtimes-'));
+  try {
+    for (const [version, pair] of Object.entries(manifest)) {
+      await mkdir(join(temporary, version));
+      for (const file of files) {
+        const url = `https://github.com/infercat/infercat/releases/download/v${version}/${file}`;
+        await writeFile(join(temporary, version, file), await checked(url, pair[file], fetcher));
+      }
+    }
+    if (!manifest[current]) {
+      await mkdir(join(temporary, current));
+      for (const file of files) await cp(join(directory, file), join(temporary, current, file));
+    }
+    await mkdir(join(directory, 'v'), { recursive: true });
+    for (const version of [...Object.keys(manifest), ...(!manifest[current] ? [current] : [])]) await cp(join(temporary, version), join(directory, 'v', version), { recursive: true });
+  } finally { await rm(temporary, { recursive: true, force: true }); }
+}
+export async function verifyRuntimes(manifest, origin, fetcher = fetch) {
+  validate(manifest);
+  for (const [version, pair] of Object.entries(manifest)) for (const file of files) {
+    const url = `${origin.replace(/\/$/, '')}/v/${version}/${file}`;
+    await checked(url, pair[file], fetcher, true);
+    console.log(`PASS ${url}: 200, CORS *, SHA-256 ${pair[file]}`);
+  }
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  const manifest = JSON.parse(await readFile(manifestURL, 'utf8'));
+  if (process.argv[2] === '--verify') await verifyRuntimes(manifest, process.argv[3] ?? 'https://infercat.ai');
+  else {
+    if (process.argv.length !== 4) throw new Error('Usage: node hack/runtime-releases.mjs DEPLOY_DIR CURRENT_VERSION | --verify [ORIGIN]');
+    await stageRuntimes(manifest, resolve(process.argv[2]), process.argv[3]);
+    console.log(`Staged ${Object.keys(manifest).length} released runtime pairs; current ${process.argv[3]}`);
+  }
+}

--- a/hack/runtime-releases.test.mjs
+++ b/hack/runtime-releases.test.mjs
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { mkdtemp, mkdir, readFile, writeFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { stageRuntimes, verifyRuntimes } from './runtime-releases.mjs';
+const names=['infercat.wasm.gz','wasm_exec.js'];
+const bytes=(v,f)=>Buffer.from(`${v}/${f}`);
+const manifest=Object.fromEntries(['0.1.3','0.1.4'].map(v=>[v,Object.fromEntries(names.map(f=>[f,createHash('sha256').update(bytes(v,f)).digest('hex')]))]));
+const fetcher=async url=>{const parts=url.split('/');return new Response(bytes(parts.at(-2).replace(/^v/,''),parts.at(-1)),{headers:{'access-control-allow-origin':'*'}});};
+async function directory(t){const dir=await mkdtemp(join(tmpdir(),'runtime-pairs-'));t.after(()=>rm(dir,{recursive:true,force:true}));for(const f of names)await writeFile(join(dir,f),'local build');return dir;}
+test('stages both archived pairs on a fresh deploy and keeps them when a new version is added',async t=>{
+ const dir=await directory(t);await stageRuntimes(manifest,dir,'0.1.5-dev',fetcher);
+ for(const v of Object.keys(manifest))for(const f of names)assert.deepEqual(await readFile(join(dir,'v',v,f)),bytes(v,f));
+ assert.equal(await readFile(join(dir,'v','0.1.5-dev',names[0]),'utf8'),'local build');
+ const next={...manifest,'0.1.5':manifest['0.1.4']};await stageRuntimes(next,dir,'0.1.5',async url=>fetcher(url.replace('v0.1.5/','v0.1.4/')));
+ assert.equal(await readFile(join(dir,'v','0.1.3',names[0]),'utf8'),'0.1.3/infercat.wasm.gz');
+});
+test('a stable deployed version uses release bytes rather than the local rebuild',async t=>{
+ const dir=await directory(t);await stageRuntimes(manifest,dir,'0.1.4',fetcher);assert.deepEqual(await readFile(join(dir,'v','0.1.4',names[0])),bytes('0.1.4',names[0]));
+});
+for(const [reason,download] of [['missing',async()=>new Response('',{status:404})],['mismatch',async()=>new Response('wrong')]])test(`${reason} asset stops staging without changing an existing pair`,async t=>{
+ const dir=await directory(t);await mkdir(join(dir,'v','0.1.3'),{recursive:true});await writeFile(join(dir,'v','0.1.3',names[0]),'kept');
+ await assert.rejects(stageRuntimes(manifest,dir,'0.1.5-dev',download));assert.equal(await readFile(join(dir,'v','0.1.3',names[0]),'utf8'),'kept');assert.ok(!(await readdir(dir)).some(n=>n.startsWith('.runtimes-')));
+});
+test('an unlisted stable version refuses before fetching',async t=>{const dir=await directory(t);await assert.rejects(stageRuntimes(manifest,dir,'0.1.5',()=>assert.fail('fetched')),/missing from runtime manifest/);});
+test('invalid manifest paths and incomplete pairs refuse',async t=>{const dir=await directory(t);for(const m of [{}, {'../escape':manifest['0.1.3']},{'0.1.3':{'wasm_exec.js':'x'}}])await assert.rejects(stageRuntimes(m,dir,'0.1.5-dev',fetcher));});
+test('live verification requires actual bytes and CORS, not a 200 HTML fallback',async()=>{
+ await verifyRuntimes(manifest,'https://site.example',fetcher);
+ await assert.rejects(verifyRuntimes(manifest,'https://site.example',async()=>new Response('fallback',{headers:{'access-control-allow-origin':'*'}})),/SHA-256/);
+ await assert.rejects(verifyRuntimes(manifest,'https://site.example',async()=>new Response('x')),/CORS/);
+});

--- a/hosting/cloudflare/runtime-releases.json
+++ b/hosting/cloudflare/runtime-releases.json
@@ -1,0 +1,10 @@
+{
+  "0.1.3": {
+    "infercat.wasm.gz": "d944d5b5f843d8b55d4b165fd7067b957a90f69ed8b0556bd11614403343843e",
+    "wasm_exec.js": "0c949f4996f9a89698e4b5c586de32249c3b69b7baadb64d220073cc04acba14"
+  },
+  "0.1.4": {
+    "infercat.wasm.gz": "5437dda4f0bdde72b981ffcb27f898a819880e11c836d65b1e26c515bb3002dd",
+    "wasm_exec.js": "0c949f4996f9a89698e4b5c586de32249c3b69b7baadb64d220073cc04acba14"
+  }
+}


### PR DESCRIPTION
Every Pages deploy now stages the archived WASM/Go runtime pairs listed in a retained release manifest, beginning with 0.1.3 and 0.1.4. It verifies the downloaded release hashes and stops before publication on failure. Stable versions use archived bytes; local dev builds keep a separate dev path.

The release runbook now requires appending the new pair without removing older entries, deploying through make deploy-web, and verifying every live version's HTTP 200, CORS and hash. The live verifier rejects HTML fallbacks as well as missing CORS.

Validation: seven runtime fixtures, real downloads of all four release assets matching their published hashes, and make check. Pre-deploy verification reproduces the live 0.1.3 404; post-deploy verification remains the landing gate's step.
