### PR TITLE
Request every offered host tool and show captured search details

### DIFF
--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -66,3 +66,5 @@ appear in prompt logs like any other message text.
 
 Stopping the chat cancels its pending search/model work. Image jobs already
 submitted by `make_image` remain independent and finish under their own limits.
+
+App friends can ask in chat: the app requests every host tool the host offers, including search on a search-only host, and Details opens the captured search results.

--- a/hosting/README.md
+++ b/hosting/README.md
@@ -33,7 +33,7 @@ code in the box. No invite is ever committed. To remint (the old key paused or r
 
 ```
 infercat keys add reddit-public-2 --max-concurrent 30 --max-output-tokens 8192 --rpm 100000 --tpm 100000000 --daily-tokens 10000000000 --json --no-qr
-wrangler kv key put --config hosting/cloudflare/wrangler.toml --binding SIGNUPS --remote link:try 'https://infercat.ai#ic1.…'
+wrangler kv key put --config hosting/cloudflare/wrangler.toml --binding SIGNUPS --remote link:try 'https://infercat.ai#ic2.…'
 ```
 
 The change is live within a minute; nothing is deployed. Without a stored link, `/try` opens the

--- a/web/dev/fake-backend.ts
+++ b/web/dev/fake-backend.ts
@@ -25,7 +25,7 @@ export interface FakeResponse {
 }
 
 export interface FakeOptions {
-  hostTools?: boolean;
+  hostTools?: boolean | string[];
   agent?: boolean;
   imageJobs?: boolean;
   runState?: string;
@@ -123,7 +123,7 @@ export function fakeMe(opts: FakeOptions = {}) {
   const models = opts.models ?? ['gemma-4-e2b-it', 'deepseek-v4-flash'];
   return {
     ...(opts.agent ? { agent: true } : {}),
-    ...(opts.hostTools ? { host_tools: ['make_image'] } : {}),
+    ...(opts.hostTools ? { host_tools: Array.isArray(opts.hostTools) ? opts.hostTools : ['make_image'] } : {}),
     key: { id: 'k_7f3a2b', name: 'alice', status: opts.keyPaused && pauseBit ? 'paused' : 'active' },
     limits: { ...LIMITS, ...(opts.imageJobs ? { daily_images: imageControl.daily, max_queued_images: 8 } : {}) },
     usage: { ...counters, ...(opts.imageJobs ? { today_images: fakeImageJobs().filter((j) => j.state === 'done').length } : {}) },
@@ -152,7 +152,7 @@ export function handleFake(req: FakeRequest, opts: FakeOptions = {}): FakeRespon
   }
 
   if (opts.imageJobs) { const image = handleImageJobs(req); if (image) return image; }
-  if (opts.agent || opts.imageJobs) { const run = handleFakeRuns(req, opts.runState); if (run) return run; }
+  if (opts.agent || opts.imageJobs || opts.hostTools) { const run = handleFakeRuns(req, opts.runState); if (run) return run; }
 
   if (path === '/me') {
     if (revokedBit) return error(403, 'permission_error', 'key_revoked', 'This invite was revoked by the host.');

--- a/web/dev/fake-chat-tools.ts
+++ b/web/dev/fake-chat-tools.ts
@@ -2,17 +2,22 @@ import { runs, scriptedRun, updateRun } from './fake-runs';
 import { handleImageJobs } from './fake-image-jobs';
 import type { FakeRequest, FakeResponse } from './fake-backend';
 export function fakeChatTools(req: FakeRequest): FakeResponse | undefined {
- const body=JSON.parse(req.body||'{}'); if(!body.host_tools?.includes('make_image')) return;
+ const body=JSON.parse(req.body||'{}'); if(!body.host_tools?.length) return;
  const id=`chat-${runs.size+1}`, record={...scriptedRun(id,'running'),kind:'chat',client_request_id:body.client_request_id,input:body,steps:[],outputs:[],key_id:'k_7f3a2b'};
  runs.set(id,record);updateRun(id,{});
  return {status:200,headers:{'content-type':'text/event-stream'},sse:(async function*(){
   yield `event: run\ndata: ${JSON.stringify({run_id:id})}\n\n`;
-  yield 'data: {"choices":[{"delta":{"content":"Your fox pictures are being made."}}]}\n\n';
+  yield `data: ${JSON.stringify({choices:[{delta:{content:body.host_tools.includes('make_image')?'Your fox pictures are being made.':'I found four sources about foxes.'}}]})}\n\n`;
+  const steps=[];
+  if(body.host_tools.includes('web_search')) steps.push({id:'search-1',type:'step' as const,at:record.created,kind:'search' as const,tool:'web_search',name:'Search web',result:'4 results',output_id:'search',status:'done' as const});
+  if(body.host_tools.includes('make_image')) {
   const step={id:'tool-1',type:'step' as const,at:record.created,kind:'other' as const,tool:'make_image',name:'Make image',result:'submitting image jobs; outcome not confirmed',status:'running' as const};updateRun(id,{steps:[step]});
   const response=handleImageJobs({...req,path:'/v1/images/jobs',body:JSON.stringify({prompts:['A red fox in snow.','A fox under a tree.'],conversation:body.conversation,client_request_id:body.client_request_id})})!;
   for(const job of JSON.parse(response.body!).jobs) updateRun(job.id,{input:{...job.input,parent_run_id:id,tool_call_id:step.id}});
+  steps.push({...step,status:'done' as const,result:'submitted 2 image jobs'});
+  }
   await new Promise(resolve=>setTimeout(resolve,250));
-  updateRun(id,{state:'done',steps:[{...step,status:'done',result:'submitted 2 image jobs'}],attempts:[{id:'model',dispatched:true,settled:true,accounting_uncertain:false,usage:{prompt_tokens:100,completion_tokens:20}}]});
+  updateRun(id,{state:'done',steps,attempts:[{id:'model',dispatched:true,settled:true,accounting_uncertain:false,usage:{prompt_tokens:100,completion_tokens:20}}]});
   yield 'data: {"choices":[],"usage":{"prompt_tokens":100,"completion_tokens":20}}\n\ndata: [DONE]\n\n';
  })()};
 }

--- a/web/dev/search-tools-check.mjs
+++ b/web/dev/search-tools-check.mjs
@@ -1,0 +1,25 @@
+import { chromium } from 'playwright';
+import { createServer } from 'vite';
+import { mkdirSync } from 'node:fs';
+import assert from 'node:assert/strict';
+const out='/private/tmp/infercat-167-screens';mkdirSync(out,{recursive:true});
+const server=await createServer({server:{host:'127.0.0.1',port:0}});await server.listen();const browser=await chromium.launch();let checks=0;
+const ok=(v,m)=>{assert.ok(v,m);checks++;};
+try{for(const tools of [['make_image'],['web_search'],['make_image','web_search']])for(const width of [390,1280])for(const lang of ['en','zh']){
+ const ctx=await browser.newContext({viewport:{width,height:width===390?844:900}}),page=await ctx.newPage(),errors=[];page.on('pageerror',e=>errors.push(e.message));
+ await page.addInitScript(lang=>window.localStorage.setItem('bn.language',JSON.stringify(lang)),lang);
+ await page.goto(`http://127.0.0.1:${server.httpServer.address().port}/?fake&hostTools=${tools.join(',')}${tools.includes('make_image')?'&imageJobs':''}&connectMs=20&invite=ic1.tcRUNproofaddressRUNproofaddress.${'D'.repeat(43)}&autoconnect`);
+ await page.locator('.composer textarea').waitFor();await page.waitForFunction(()=>!document.querySelector('.composer textarea').disabled);
+ await page.evaluate(async()=>{const {TunnelTransport}=await import('/src/transport/index.ts'),old=TunnelTransport.prototype.fetch;window.__requests=[];TunnelTransport.prototype.fetch=function(path,init){window.__requests.push({path,body:init?.body,auth:new window.Headers(init?.headers).has('authorization')});return old.call(this,path,init);};});
+ await page.locator('.composer textarea').fill('Find the fox facts, then draw a fox if you can.');await page.locator('.composer .primary').click();await page.locator('.steps summary').waitFor();await page.locator('.steps summary').click();
+ await page.waitForFunction(n=>document.querySelectorAll('.steps .step').length===n,tools.length);
+ const asked=await page.evaluate(()=>window.__requests.filter(r=>r.path==='/v1/chat/completions'));ok(asked.length===1,'one request');assert.deepEqual(JSON.parse(asked[0].body).host_tools,tools);checks++;
+ ok(await page.locator('.steps .step').count()===tools.length,'all offered steps');
+ if(tools.includes('web_search')){
+  await page.locator('.steps button.r').filter({hasText:'4'}).click();await page.locator('.sheet.file pre').waitFor();ok((await page.locator('.sheet.file pre').innerText()).includes('Four search results'),'captured result opened');ok(await page.evaluate(()=>window.__requests.some(r=>r.path.endsWith('/outputs/search')&&r.auth)),'authenticated scoped output read');await page.keyboard.press('Escape');
+ }
+ if(tools.includes('make_image')){await page.waitForFunction(()=>document.querySelectorAll('.row.run').length===3);ok(true,'image rows retained alongside tool steps');}
+ await page.evaluate(()=>document.fonts.ready);ok(await page.evaluate(()=>document.documentElement.scrollWidth<=window.innerWidth),'no overflow');await page.screenshot({path:`${out}/${tools.join('-')}-${width}-${lang}.png`});
+ if(tools.length===1&&tools[0]==='web_search'){await page.reload();await page.locator('.steps summary').waitFor();ok(await page.locator('.row.run').count()===1,'search-only reconnect retains one trace');}
+ ok(errors.length===0,errors.join('\n'));await ctx.close();
+}console.log(`${checks} passed / 0 failed; 12 captures; ${out}`);}finally{await browser.close();await server.close();}

--- a/web/src/chat-tools.test.ts
+++ b/web/src/chat-tools.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest';
-import { offersImageTool, mergeChatRuns } from './chatTools';
+import { offersHostTools, mergeChatRuns } from './chatTools';
 import { fakeMe } from '../dev/fake-backend';
 import { scriptedRun } from '../dev/fake-runs';
 import { mergeImageJobs, type ImageJob } from './imageJobs';
@@ -10,8 +10,10 @@ import { NEW_REPLY, reduceReply } from './stream';
 const conv = (): Conversation => ({id:'c',title:'fox',createdAt:1,updatedAt:1,messages:[{id:'u',role:'user',content:'fox'},{id:'reply',role:'assistant',content:'Here it is.',hostRun:{keyId:'key',requestId:'request',ids:[],records:[]}}]});
 const parent = (id='parent') => ({...scriptedRun(id,'done'),kind:'chat',client_request_id:'request',key_id:'key'});
 const child = (id='image'):ImageJob => ({...scriptedRun(id,'running'),kind:'image',output:undefined,key_id:'key',input:{prompt:'fox',parent_run_id:'parent',client_request_id:'request',tool_call_id:'tool'},batch:{id:'batch',index:0,count:1}});
-it('opts in only with both explicit offer and image model',()=>{
- const me=fakeMe({imageJobs:true});expect(offersImageTool(me)).toBe(false);me.agent=true;expect(offersImageTool(me)).toBe(false);me.host_tools=['make_image'];expect(offersImageTool(me)).toBe(true);delete me.host.images;expect(offersImageTool(me)).toBe(false);
+it('opts in for any offered host tool, independent of image and agent capabilities',()=>{
+ const me=fakeMe({});expect(offersHostTools(me)).toBe(false);me.agent=true;expect(offersHostTools(me)).toBe(false);
+ for(const tools of [['make_image'],['web_search'],['make_image','web_search']]){me.host_tools=tools;expect(offersHostTools(me)).toBe(true);}
+ me.host_tools=[];expect(offersHostTools(me)).toBe(false);
 });
 it('associates all parent ids without replacing the streamed prose or duplicating on reset',()=>{
  let cs=mergeChatRuns([conv()],[parent(),parent('other')],'key');cs=mergeChatRuns(cs,[parent()],'key');

--- a/web/src/chatTools.ts
+++ b/web/src/chatTools.ts
@@ -1,7 +1,7 @@
-import { hostImages, type Me, type RunRecord } from './api';
+import { type Me, type RunRecord } from './api';
 import type { Conversation, Message } from './storage';
 import { runItem } from './runs';
-export const offersImageTool = (me: Me): boolean => Boolean(hostImages(me)?.model && me.host_tools?.includes('make_image'));
+export const offersHostTools = (me: Me): boolean => Boolean(me.host_tools?.length);
 /** Correlation never deduplicates creation: all matching parent ids remain visible. */
 export function mergeChatRuns(convs: Conversation[], records: RunRecord[], keyId?: string): Conversation[] {
   const owners = new Map<string, number>();

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -16,7 +16,7 @@ async function boot(): Promise<void> {
   if (import.meta.env.DEV && q.has('fake')) {
     const { installFakeTunnel } = await import('../dev/fake-infercat-tunnel.ts');
     installFakeTunnel({
-      hostTools: q.has('hostTools'), imageJobs: q.has('imageJobs'), agent: q.has('agent'), runState: q.get('runState') ?? 'running',
+      hostTools: q.get('hostTools') ? q.get('hostTools')!.split(',') : q.has('hostTools'), imageJobs: q.has('imageJobs'), agent: q.has('agent'), runState: q.get('runState') ?? 'running',
       transcriptions: q.has('transcriptions'), speech: q.has('speech'),
       ...(q.has('audioFailure') ? { audioFailure: Number(q.get('audioFailure')) } : {}),
       ...(q.has('audioDelay') ? { audioDelayMs: Number(q.get('audioDelay')) } : {}),

--- a/web/src/ui/Chat.tsx
+++ b/web/src/ui/Chat.tsx
@@ -1,4 +1,4 @@
-import { offersImageTool } from '../chatTools';
+import { offersHostTools } from '../chatTools';
 import ChatToolSteps from './ChatToolSteps';
 import { hostImages } from '../api';
 import { useImageJobs } from './useImageJobs';
@@ -390,8 +390,8 @@ export default function Chat({ state, live, dispatch, onRedial, reconnecting = f
       if (history.some((m) => !leftOut.includes(m) && m.images?.some((i) => !data[i.id]))) {
         setMissingChats((seen) => new Set(seen).add(convId));
       }
-      const toolChat = !me.agent && offersImageTool(me);
-      const request = { ...(toolChat ? { host_tools: ['make_image'], conversation: convId, client_request_id: replyId } : {}), model, messages, temperature: settings.temperature, ...thinkingFields(settings.thinking) };
+      const toolChat = !me.agent && offersHostTools(me);
+      const request = { ...(toolChat ? { host_tools: [...me.host_tools!], conversation: convId, client_request_id: replyId } : {}), model, messages, temperature: settings.temperature, ...thinkingFields(settings.thinking) };
       if (me.agent && history.some((m) => !leftOut.includes(m) && m.images?.some((image) => !data[image.id]))) { setImageNotice(rejectionNotice({ reason: 'missing_image', message: tr('app_image_missing') })); setStreaming(false); abort.current = null; return; }
       if (!fitsRequest(request)) {
         setImageNotice(rejectionNotice({ reason: 'body_too_large', message: tr('app_over_message_size', { size: '4 MB' }) }));
@@ -729,7 +729,7 @@ export default function Chat({ state, live, dispatch, onRedial, reconnecting = f
                   onContinue={() => send(tr('app_continue_from_where_you_stopped'))}
                   onNewChat={startNew}
                   onResend={resend}
-                /></div>{m.hostRun?.records.map(record => <ChatToolSteps key={record.id} record={record} host={host} connected={agentRuns.connected} />)}</Fragment>
+                /></div>{m.hostRun?.records.map(record => <ChatToolSteps key={record.id} record={record} live={live} host={host} connected={agentRuns.connected} />)}</Fragment>
               ))
             )}
           </div>

--- a/web/src/ui/ChatToolSteps.tsx
+++ b/web/src/ui/ChatToolSteps.tsx
@@ -1,8 +1,11 @@
-import type { RunRecord } from '../api';
+import { runOutput, timeoutSignal, type RunRecord } from '../api';
+import type { Live } from '../session';
+import { useCallback } from 'react';
 import { runView } from './RunItem';
 import RunRow from './Run';
 /** The streamed reply owns prose, errors and metering; this is only its tool trace. */
-export default function ChatToolSteps({ record, host, connected }: { record: RunRecord; host: string; connected: boolean }) {
-  const view = runView(record); view.steps = view.steps.filter(s => s.tool === 'make_image'); view.text = undefined;
-  return view.steps.length ? <RunRow stepsOnly run={view} host={host} connected={connected} disabled pending={false} onCancel={() => {}} onAnswer={() => {}} onRetry={() => {}} /> : null;
+export default function ChatToolSteps({ record, host, connected, live }: { record: RunRecord; live: Live; host: string; connected: boolean }) {
+  const loadText = useCallback((id: string) => runOutput(live.transport, live.secret, record.id, id, timeoutSignal(15000)).then(b => b.text()), [live.transport, live.secret, record.id]);
+  const view = runView(record); view.steps = view.steps.filter(s => Boolean(s.tool)); view.text = undefined;
+  return view.steps.length ? <RunRow loadText={loadText} stepsOnly run={view} host={host} connected={connected} disabled pending={false} onCancel={() => {}} onAnswer={() => {}} onRetry={() => {}} /> : null;
 }

--- a/web/src/ui/useRuns.ts
+++ b/web/src/ui/useRuns.ts
@@ -1,3 +1,4 @@
+import { offersHostTools } from '../chatTools';
 import { hostImages } from '../api';
 import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { timeoutSignal, answerRun, cancelRun, describeError, GatewayError, getRun, listRuns, submitRun, type ChatRequest, type RunRecord } from '../api';
@@ -13,7 +14,7 @@ export function useRuns(live: Live, enabled: boolean, convs: Conversation[], set
   useEffect(() => { const held = requests.current; return () => { held.forEach((c) => c.abort()); }; }, [live.transport, live.secret, enabled]);
   const merge = (records: RunRecord[]) => setConvs((prev) => mergeRunRecords(prev, records.filter((r) => ['agent','chat'].includes(r.kind)), live.me.key.id));
   useEffect(() => {
-    if (!enabled || live.offline || live.key !== 'active' || (!live.me.agent && !hostImages(live.me)?.model)) return;
+    if (!enabled || live.offline || live.key !== 'active' || (!live.me.agent && !hostImages(live.me)?.model && !offersHostTools(live.me))) return;
     const ac = new AbortController();
     void followRuns({ transport: live.transport, secret: live.secret, signal: ac.signal,
       onEvent: (signal) => { void latest.current.imagesChanged?.(signal).catch((error) => { if (!signal.aborted) dispatch({ t: 'streamError', code: error instanceof GatewayError ? error.code : '', error: describeError(error, live.me.host.name) }); }); return Promise.resolve(); },
@@ -23,7 +24,7 @@ export function useRuns(live: Live, enabled: boolean, convs: Conversation[], set
       failed(error) { if (!ac.signal.aborted) dispatch({ t: 'streamError', code: error instanceof GatewayError ? error.code : '', error: describeError(error, live.me.host.name) }); },
     });
     return () => { ac.abort(); setConnected(false); };
-  }, [enabled, live.offline, live.key, live.me.agent, hostImages(live.me)?.model, live.transport, live.secret, live.me.host.name, live.me.key.id, setConvs, dispatch]);
+  }, [enabled, live.offline, live.key, live.me.agent, offersHostTools(live.me), hostImages(live.me)?.model, live.transport, live.secret, live.me.host.name, live.me.key.id, setConvs, dispatch]);
   async function act(item: RunItem, answer?: { id: string; allow: boolean }) {
     const current = latest.current;
     if (!current.enabled || current.live.offline || current.live.key !== 'active' || !item.run || active.current.has(item.id)) return;


### PR DESCRIPTION
The app now requests every tool listed in /me.host_tools, including on search-only hosts. The shared run subscription handles those hosts, and chat Details shows every tool-bearing step with authenticated, bounded reads of captured results. No new control is added.

SEARCH.md now says friends can ask in chat; the hosting remint example uses ic2. Fixtures cover image-only, search-only and combined offers, result reads, and search-only reload recovery.

Validation: 490 web tests, typecheck/lint, 88 browser checks with 12 EN/ZH captures at 390/1280, and make check. Rebased cleanly onto 165's landing f96ede1 with an identical patch hash.
