### PR TITLE
171: Consolidate CLI mirrors and shared atomic writes

### DIFF
--- a/cmd/infercat/config.go
+++ b/cmd/infercat/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/infercat/infercat/internal/fsx"
 	"github.com/infercat/infercat/internal/product"
 )
 
@@ -87,31 +88,8 @@ func saveConfig(dataDir string, c config) error {
 	return writeFileAtomic(filepath.Join(dataDir, configName), append(b, '\n'))
 }
 
-// writeFileAtomic writes through a sibling temp file so a crash never leaves a half file.
 func writeFileAtomic(path string, b []byte) error {
-	dir := filepath.Dir(path)
-	f, err := os.CreateTemp(dir, "."+filepath.Base(path)+"-*")
-	if err != nil {
-		return err
-	}
-	name := f.Name()
-	defer os.Remove(name)
-	if err := f.Chmod(0o600); err != nil {
-		f.Close()
-		return err
-	}
-	if _, err := f.Write(b); err != nil {
-		f.Close()
-		return err
-	}
-	if err := f.Sync(); err != nil {
-		f.Close()
-		return err
-	}
-	if err := f.Close(); err != nil {
-		return err
-	}
-	return os.Rename(name, path)
+	return fsx.WriteFile(path, b, 0600)
 }
 
 func intOr(v, def int) int {

--- a/cmd/infercat/console.go
+++ b/cmd/infercat/console.go
@@ -251,7 +251,7 @@ func (e *env) consoleAPI(store *keys.FileStore, addr string, up upstream.Upstrea
 		return map[string]bool{"ok": true}, nil
 	}
 	result := func(k *keys.Key, inv string) any {
-		return map[string]string{"key_id": k.ID, "name": k.Name, "invite": inv, "link": inviteLink(settings.DataDir, inv)}
+		return inviteJSON{k.ID, k.Name, inv, inviteLink(settings.DataDir, inv)}
 	}
 	route("POST /keys", func(w http.ResponseWriter, r *http.Request) (any, error) {
 		var in struct {

--- a/cmd/infercat/keys.go
+++ b/cmd/infercat/keys.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"strings"
-	"text/tabwriter"
 	"time"
 
 	"github.com/infercat/infercat/internal/admin"
@@ -239,17 +238,19 @@ func inviteLink(dataDir, inv string) string {
 	return strings.TrimRight(base, "#") + "#" + inv
 }
 
+type inviteJSON struct {
+	KeyID  string `json:"key_id"`
+	Name   string `json:"name"`
+	Invite string `json:"invite"`
+	Link   string `json:"link"`
+}
+
 // printInviteJSON is `keys add --json`: the four fields a script needs and nothing else, so the
 // invite can be handed to a chat bot or a provisioning script without scraping the human output.
 func (e *env) printInviteJSON(dataDir string, k *keys.Key, inv string) error {
 	enc := json.NewEncoder(e.out)
 	enc.SetIndent("", "  ")
-	return enc.Encode(struct {
-		KeyID  string `json:"key_id"`
-		Name   string `json:"name"`
-		Invite string `json:"invite"`
-		Link   string `json:"link"`
-	}{k.ID, k.Name, inv, inviteLink(dataDir, inv)})
+	return enc.Encode(inviteJSON{k.ID, k.Name, inv, inviteLink(dataDir, inv)})
 }
 
 // reloadHost pushes a key change to the running host over the admin socket so it is in force
@@ -290,7 +291,7 @@ func (e *env) keysList(ctx context.Context, pre string, args []string) error {
 		return err
 	}
 	seen := rep.LastSeen()
-	tw := tabwriter.NewWriter(e.out, 0, 0, 2, ' ', 0)
+	tw := newTable(e.out)
 	fmt.Fprintln(tw, "ID\tNAME\tSTATUS\tRPM\tTPM\tDAILY\tAUDIO S/DAY\tSPEECH CHARS/DAY\tIMAGES/DAY\tIMAGE QUEUE\tCREATED\tLAST SEEN")
 	for _, k := range list {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",

--- a/cmd/infercat/main.go
+++ b/cmd/infercat/main.go
@@ -24,13 +24,13 @@ import (
 	"github.com/infercat/infercat/internal/product"
 	runstate "github.com/infercat/infercat/internal/run"
 	"github.com/infercat/infercat/internal/supervise"
+	"github.com/infercat/infercat/internal/tunnel"
 	"github.com/infercat/infercat/internal/upstream"
 	"github.com/infercat/infercat/internal/usage"
 )
 
-// The tunnel (ticket 001) and the gateway (ticket 002) land in parallel with this CLI, so the
-// command talks to them through these two small interfaces. wire.go binds them to the real
-// packages; wire_stub.go stands in until those tickets land.
+// Injectable factories and narrow output interfaces keep the CLI testable.
+// wire.go binds them to the real tunnel and gateway.
 
 type tunnelStatus struct {
 	Addr    string
@@ -47,13 +47,7 @@ type tunnelServer interface {
 	Close() error
 }
 
-type tunnelOptions struct {
-	DataDir    string
-	Ephemeral  bool
-	DERPMapURL string
-	Region     string
-	Logf       func(string, ...any)
-}
+type tunnelOptions = tunnel.Options
 
 type gatewayServer interface {
 	ExecuteStep(context.Context, string, runstate.Step, func() error) (runstate.StepResult, error)
@@ -67,26 +61,7 @@ type gatewayServer interface {
 	Shutdown(ctx context.Context) error
 }
 
-type gatewayOptions struct {
-	Search *gateway.Search
-
-	Embed                        upstream.Engine
-	Managed                      map[string]gateway.ManagedMember
-	Images                       upstream.ImageEngine
-	ImageModel                   string
-	RemoteConsole                http.Handler
-	LiveHostName                 func() string
-	SpeechVoices                 map[string]string
-	Transcribe, Speech           upstream.AudioEngine
-	TranscribeModel, SpeechModel string
-	MaxTranscriptionSeconds      float64
-	ModelsPinned                 []string
-
-	LogPrompts  bool
-	HostName    string
-	RelayRegion func() string
-	DataDir     string // usage.jsonl, for the daily counters the gateway seeds at start
-}
+type gatewayOptions = gateway.Config
 
 // platform is everything this command cannot build for itself.
 type platform struct {
@@ -95,8 +70,6 @@ type platform struct {
 	savedAddr    func(dataDir string) (string, error)
 	encodeInvite func(addr, secret string) string
 	newGateway   func(o gatewayOptions, up upstream.Upstream, store keys.Store, rec usage.Recorder, logf func(string, ...any)) (gatewayServer, error)
-	// warn is printed once at the top of `serve` when this is not a real build.
-	warn string
 }
 
 // errDone means the command finished and printed everything it had to say (exit 0).

--- a/cmd/infercat/serve.go
+++ b/cmd/infercat/serve.go
@@ -169,9 +169,6 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 	_, keyErr := os.Stat(filepath.Join(dataDir, tunnel.KeyFile))
 	newIdentity := errors.Is(keyErr, os.ErrNotExist) && !*ephemeral
 
-	if e.plat.warn != "" {
-		e.logf("%s", e.plat.warn)
-	}
 	if *logPrompts {
 		e.logf("--log-prompts is ON: your friends' prompts and completions are being written to %s/%s.", dataDir, usage.FileName)
 	}
@@ -235,7 +232,6 @@ func (e *env) cmdServe(ctx context.Context, pre string, args []string) error {
 		Images:       images, ImageModel: *imageModel,
 		Transcribe: transcribe, Speech: speech, MaxTranscriptionSeconds: float64(*maxAudio),
 		LogPrompts:  *logPrompts,
-		HostName:    hostName,
 		RelayRegion: func() string { return tun.Status().Region },
 		DataDir:     dataDir, // today's counters are seeded from usage.jsonl there
 	}, up, store, bridge.Recorder{Next: events, Count: public.Count}, e.logf)

--- a/cmd/infercat/status.go
+++ b/cmd/infercat/status.go
@@ -267,7 +267,7 @@ func writeStatus(w io.Writer, st admin.Status) {
 		return
 	}
 	fmt.Fprintln(w)
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	tw := newTable(w)
 	fmt.Fprintln(tw, "ID\tNAME\tSTATUS\tIN FLIGHT\tRPM\tTODAY\tLAST SEEN")
 	for _, k := range st.Keys {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%d\t%d\t%s\n", k.ID, k.Name, k.Status, k.InFlight, k.RPMUsed, k.TodayTokens, ago(k.LastSeen))
@@ -287,7 +287,7 @@ func writeSessions(w io.Writer, t admin.Tunnel) {
 		}
 	}
 	fmt.Fprintf(w, "sessions  %d active of %d seen  ·  in %s  out %s  ·  paths: the client's to measure, not visible to a host\n", active, len(t.Sessions), bytesWord(t.RxBytes), bytesWord(t.TxBytes))
-	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	tw := newTable(w)
 	for _, s := range t.Sessions {
 		if s.Active {
 			fmt.Fprintf(tw, "  %s\t%s\tin %s\tout %s\tlast byte %s\tage %s\n", shortKey(s.Key), plural(s.Conns, "conn"), bytesWord(s.RxBytes), bytesWord(s.TxBytes), ago(s.LastByte), shortDur(time.Since(s.Since)))
@@ -409,3 +409,5 @@ Flags:
   --watch          redraw in place every --interval and stream requests; Ctrl-C stops
   --interval D     how often --watch redraws (default 1s)
 `
+
+func newTable(w io.Writer) *tabwriter.Writer { return tabwriter.NewWriter(w, 0, 0, 2, ' ', 0) }

--- a/cmd/infercat/usagecmd.go
+++ b/cmd/infercat/usagecmd.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"text/tabwriter"
 	"time"
 
 	"github.com/infercat/infercat/internal/keys"
@@ -76,7 +75,7 @@ func (e *env) writeUsage(rep *usage.Report, since, keyID string, names map[strin
 		fmt.Fprintln(e.out, "nothing yet")
 		return
 	}
-	fmt.Fprintf(e.out, "requests  %s%s%s\n", calls(t.ModelCalls), polls(t.AppPolls), errs(t.Errors, t.ErrorsByCode))
+	fmt.Fprintf(e.out, "requests  %s%s%s\n", plural(t.ModelCalls, "model call"), polls(t.AppPolls), errs(t.Errors, t.ErrorsByCode))
 	fmt.Fprintf(e.out, "charged   %s\n", meterTotals(t))
 	fmt.Fprintf(e.out, "observed  %s prompt  %s completion\n", comma(t.PromptTokens), comma(t.CompletionTokens))
 	fmt.Fprintf(e.out, "ttft      median %s  p95 %s\n", ms(t.TTFTMedianMS), ms(t.TTFTP95MS))
@@ -85,7 +84,7 @@ func (e *env) writeUsage(rep *usage.Report, since, keyID string, names map[strin
 	for _, via := range sortedVias(rep.ByVia) {
 		s := rep.ByVia[via]
 		fmt.Fprintf(e.out, "via %-6s %s%s%s · %s prompt  %s completion\n", via,
-			calls(s.ModelCalls), polls(s.AppPolls), errs(s.Errors, s.ErrorsByCode), comma(s.PromptTokens), comma(s.CompletionTokens))
+			plural(s.ModelCalls, "model call"), polls(s.AppPolls), errs(s.Errors, s.ErrorsByCode), comma(s.PromptTokens), comma(s.CompletionTokens))
 		fmt.Fprintf(e.out, "           charged %s\n", meterTotals(*s))
 	}
 	if rep.Malformed > 0 {
@@ -95,7 +94,7 @@ func (e *env) writeUsage(rep *usage.Report, since, keyID string, names map[strin
 		return
 	}
 	fmt.Fprintln(e.out)
-	tw := tabwriter.NewWriter(e.out, 0, 0, 2, ' ', 0)
+	tw := newTable(e.out)
 	fmt.Fprintln(tw, "ID\tNAME\tVIA\tCALLS\tPOLLS\tERR\tPROMPT\tCOMPLETION\tTTFT p50\tTOTAL p50\tLAST SEEN\tCHARGED")
 	for _, k := range rep.Keys {
 		for _, via := range sortedVias(k.ByVia) {
@@ -127,15 +126,9 @@ func sortedVias(by map[string]*usage.Stats) []string {
 	return vias
 }
 
-// calls, polls and errs write the headline the way a host reads it: what the friend did, then what
+// The model-call count, polls and errs write the headline the way a host reads it: what the friend did, then what
 // their browser did on its own, then what went wrong. A web app polls /me every 30 s, and counting
 // those as requests is what made one conversation read as 58 (ticket 009 promise 6).
-func calls(n int) string {
-	if n == 1 {
-		return "1 model call"
-	}
-	return fmt.Sprintf("%d model calls", n)
-}
 
 func polls(n int) string {
 	if n == 0 {

--- a/cmd/infercat/wire.go
+++ b/cmd/infercat/wire.go
@@ -19,13 +19,7 @@ import (
 func newPlatform() platform {
 	return platform{
 		startTunnel: func(ctx context.Context, o tunnelOptions) (tunnelServer, error) {
-			s, err := tunnel.Start(ctx, tunnel.Options{
-				DataDir:    o.DataDir,
-				Ephemeral:  o.Ephemeral,
-				DERPMapURL: o.DERPMapURL,
-				Region:     o.Region,
-				Logf:       o.Logf,
-			})
+			s, err := tunnel.Start(ctx, o)
 			if err != nil {
 				return nil, err
 			}
@@ -41,26 +35,12 @@ func newPlatform() platform {
 		savedAddr:    tunnel.SavedAddr,
 		encodeInvite: invite.Encode,
 		newGateway: func(o gatewayOptions, up upstream.Upstream, store keys.Store, rec usage.Recorder, logf func(string, ...any)) (gatewayServer, error) {
-			return gateway.New(gateway.Config{
-				Search: o.Search,
-				Embed:  o.Embed, Managed: o.Managed,
-				RemoteConsole: o.RemoteConsole, LiveHostName: o.LiveHostName,
-				Images: o.Images, ImageModel: o.ImageModel,
-				ModelsPinned:    o.ModelsPinned,
-				SpeechVoices:    o.SpeechVoices,
-				TranscribeModel: o.TranscribeModel, SpeechModel: o.SpeechModel,
-				Transcribe: o.Transcribe, Speech: o.Speech, MaxTranscriptionSeconds: o.MaxTranscriptionSeconds,
-				LogPrompts:  o.LogPrompts,
-				HostName:    o.HostName,
-				RelayRegion: o.RelayRegion,
-				DataDir:     o.DataDir,
-			}, up, store, rec, logf), nil
+			return gateway.New(o, up, store, rec, logf), nil
 		},
 	}
 }
 
-// realTunnel adapts tunnel.Status to the CLI's own struct so nothing outside this file needs
-// the tunnel package.
+// realTunnel adapts tunnel.Status to the CLI's status view.
 type realTunnel struct{ s *tunnel.Server }
 
 func (t realTunnel) Listener() net.Listener { return t.s.Listener() }

--- a/internal/adminkey/store.go
+++ b/internal/adminkey/store.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/infercat/infercat/internal/fsx"
 )
 
 type State struct {
@@ -102,25 +104,7 @@ func (s *Store) Mint(rotate bool) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	f, err := os.CreateTemp(filepath.Dir(s.path), ".admin-*")
-	if err != nil {
-		return "", err
-	}
-	defer os.Remove(f.Name())
-	defer f.Close()
-	if err = f.Chmod(0600); err == nil {
-		_, err = f.Write(b)
-	}
-	if err == nil {
-		err = f.Sync()
-	}
-	if err == nil {
-		err = f.Close()
-	}
-	if err == nil {
-		err = os.Rename(f.Name(), s.path)
-	}
-	if err != nil {
+	if err = fsx.WriteFile(s.path, b, 0600); err != nil {
 		return "", err
 	}
 	s.warning = false

--- a/internal/agentconfig/config.go
+++ b/internal/agentconfig/config.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/infercat/infercat/internal/fsx"
 )
 
 type Config struct{ Dir, DSH string }
@@ -136,25 +138,7 @@ func write(path string, raw []byte) error {
 	if fi, err := os.Stat(path); err == nil {
 		mode = fi.Mode().Perm()
 	}
-	f, err := os.CreateTemp(filepath.Dir(path), ".infercat-*")
-	if err != nil {
-		return err
-	}
-	defer os.Remove(f.Name())
-	defer f.Close()
-	if err = f.Chmod(mode); err == nil {
-		_, err = f.Write(raw)
-	}
-	if err == nil {
-		err = f.Sync()
-	}
-	if err == nil {
-		err = f.Close()
-	}
-	if err == nil {
-		err = os.Rename(f.Name(), path)
-	}
-	return err
+	return fsx.WriteFile(path, raw, mode)
 }
 func (c *Config) locked(fn func() error) error {
 	var err error

--- a/internal/fsx/fsx.go
+++ b/internal/fsx/fsx.go
@@ -1,0 +1,45 @@
+// Package fsx writes a complete replacement through a synced sibling file.
+package fsx
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteFile replaces path atomically; its parent directory must already exist.
+func WriteFile(path string, b []byte, mode os.FileMode) error {
+	// Run-store recovery recognizes this prefix; keep it shared and fixed.
+	f, err := os.CreateTemp(filepath.Dir(path), ".run-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if err = f.Chmod(mode); err == nil {
+		_, err = f.Write(b)
+	}
+	if err == nil {
+		err = f.Sync()
+	}
+	closeErr := f.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return os.Rename(f.Name(), path)
+}
+
+// WriteFileSyncDir also syncs the renamed directory entry. A directory-sync
+// error is returned after the replacement, as required by the run-store seam.
+func WriteFileSyncDir(path string, b []byte, mode os.FileMode) error {
+	if err := WriteFile(path, b, mode); err != nil {
+		return err
+	}
+	d, err := os.Open(filepath.Dir(path))
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	return d.Sync()
+}

--- a/internal/fsx/fsx_test.go
+++ b/internal/fsx/fsx_test.go
@@ -1,0 +1,41 @@
+package fsx
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReplacementBytesModesAndFailureCleanup(t *testing.T) {
+	for name, write := range map[string]func(string, []byte, os.FileMode) error{"file": WriteFile, "directory": WriteFileSyncDir} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "state")
+			for _, mode := range []os.FileMode{0600, 0640} {
+				want := []byte{0, byte(mode), '\n', 255}
+				if err := write(path, want, mode); err != nil {
+					t.Fatal(err)
+				}
+				got, err := os.ReadFile(path)
+				if err != nil || !bytes.Equal(got, want) {
+					t.Fatal("replacement bytes", got, err)
+				}
+				info, err := os.Stat(path)
+				if err != nil || info.Mode().Perm() != mode {
+					t.Fatal("replacement mode", info, err)
+				}
+			}
+			if err := os.Mkdir(filepath.Join(dir, "blocked"), 0700); err != nil {
+				t.Fatal(err)
+			}
+			if err := write(filepath.Join(dir, "blocked"), []byte("refused"), 0600); err == nil {
+				t.Fatal("replaced a directory")
+			}
+			left, err := filepath.Glob(filepath.Join(dir, ".run-*"))
+			if err != nil || len(left) != 0 {
+				t.Fatal("temporary files leaked", left, err)
+			}
+		})
+	}
+}

--- a/internal/gateway/fakes_test.go
+++ b/internal/gateway/fakes_test.go
@@ -492,8 +492,8 @@ func newHarness(t *testing.T, cfg Config, up upstream.Engine) *harness {
 	}
 	h.key = defaultKey()
 	h.store.set(testSecret, h.key)
-	if cfg.HostName == "" {
-		cfg.HostName = "max-laptop"
+	if cfg.LiveHostName == nil {
+		cfg.LiveHostName = func() string { return "max-laptop" }
 	}
 	var rec usage.Recorder = h.rec
 	if cfg.DataDir != "" {

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -42,7 +42,6 @@ type Config struct {
 	MaxTranscriptionSeconds      float64
 	ModelsPinned                 []string      // host-wide model allowlist; empty means all models
 	LogPrompts                   bool          // put prompt/completion text into usage events (Protection 3: opt-in)
-	HostName                     string        // shown in /me
 	RelayRegion                  func() string // shown in /me; nil → ""
 	// DataDir is where usage.jsonl lives; New reads it once to seed today's per-key counters.
 	// Empty means no history to seed from, and the counters start at zero as they always did.

--- a/internal/gateway/gateway_test.go
+++ b/internal/gateway/gateway_test.go
@@ -96,7 +96,7 @@ func TestNotFound(t *testing.T) {
 }
 
 func TestMeShape(t *testing.T) {
-	h := newHarness(t, Config{HostName: "maxbox", RelayRegion: func() string { return "sfo" }}, nil)
+	h := newHarness(t, Config{LiveHostName: func() string { return "maxbox" }, RelayRegion: func() string { return "sfo" }}, nil)
 	h.setKey(func(k *keys.Key) { k.Limits.Models = []string{"m2", "ghost"}; k.Limits.RPM = 20 })
 	h.up.setInfo(func(i *upstream.Info) { i.ModelContext = 8192 })
 	r := h.get("/me")
@@ -521,7 +521,7 @@ func TestRestartKeepsTodaysCountersAndLastSeen(t *testing.T) {
 	if err := h.file.Close(); err != nil {
 		t.Fatal(err)
 	}
-	h.gw = New(Config{DataDir: dir, HostName: "max-laptop"}, h.up, h.store, h.rec, globalLogs.logf)
+	h.gw = New(Config{DataDir: dir, LiveHostName: func() string { return "max-laptop" }}, h.up, h.store, h.rec, globalLogs.logf)
 	h.srv = httptest.NewServer(h.gw.Handler())
 	defer h.srv.Close()
 

--- a/internal/gateway/live_test.go
+++ b/internal/gateway/live_test.go
@@ -114,7 +114,7 @@ func TestLiveLlamaCPP(t *testing.T) {
 	}
 	t.Logf("upstream: %+v", up.info)
 
-	h := newHarness(t, Config{HostName: "live-laptop", RelayRegion: func() string { return "loopback" }}, up)
+	h := newHarness(t, Config{LiveHostName: func() string { return "live-laptop" }, RelayRegion: func() string { return "loopback" }}, up)
 	h.setKey(func(k *keys.Key) { k.Limits = keys.DefaultLimits() })
 
 	r := h.get("/me")

--- a/internal/gateway/proxy.go
+++ b/internal/gateway/proxy.go
@@ -398,7 +398,6 @@ func (q *request) me() {
 	m.Usage.TodaySearches = cnt.TodaySearches
 	m.Usage.RPMUsed, m.Usage.TPMUsed, m.Usage.TodayTokens, m.Usage.InFlight = cnt.RPMUsed, cnt.TPMUsed, cnt.TodayTokens, cnt.InFlight
 	info := q.g.router.text.Up.Info()
-	m.Host.Name = q.g.cfg.HostName
 	if q.g.cfg.LiveHostName != nil {
 		m.Host.Name = q.g.cfg.LiveHostName()
 	}

--- a/internal/keys/keys.go
+++ b/internal/keys/keys.go
@@ -70,20 +70,6 @@ type Store interface {
 	List(ctx context.Context) ([]*Key, error)
 }
 
-// Admin is the CLI-side write surface (ticket 003). Not used by the gateway.
-type Admin interface {
-	Store
-	// Add creates a key and returns it with the plaintext secret (shown once).
-	Add(ctx context.Context, name string, l Limits) (k *Key, secret string, err error)
-	SetStatus(ctx context.Context, id string, s Status) error
-	// Rotate replaces the secret, keeping id, limits, and history; returns the new plaintext secret.
-	Rotate(ctx context.Context, id string) (secret string, err error)
-	SetLimits(ctx context.Context, id string, l Limits) error
-}
-
-// HashSecret returns the canonical "sha256:<hex>" form used in keys.json.
-// Implemented in hash.go (PM-owned) so 002 and 003 share one definition.
-
 // AudioDefaults applies new fields to legacy keys in memory without rewriting the key file.
 func AudioDefaults(l Limits) Limits {
 	if l.DailyAudioSeconds == 0 {

--- a/internal/keys/store.go
+++ b/internal/keys/store.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/infercat/infercat/internal/fsx"
 )
 
 // ErrNotFound is returned when no key matches the given id or name.
@@ -36,7 +38,7 @@ type stamp struct {
 	size int64
 }
 
-// FileStore implements Admin (and therefore Store) over keys.json.
+// FileStore implements Store over keys.json.
 //
 // Reads are hot: the file is re-stat'ed at most once per second and re-read when the stamp
 // changes, so `keys add` in one process is visible to a running gateway in another without a
@@ -75,9 +77,6 @@ func (s *FileStore) Changes() <-chan struct{} {
 	}
 	return s.changes
 }
-
-// Path is the file this store reads and writes.
-func (s *FileStore) Path() string { return s.path }
 
 // Reload re-reads keys.json now, past the once-per-second throttle. The CLI pokes a running host
 // through the admin socket after every key write so a pause, resume, revoke, or rotate is in
@@ -369,7 +368,6 @@ func (s *FileStore) newID() (string, error) {
 	return "", errors.New("could not find a free key id")
 }
 
-// save writes keys.json atomically: a sibling temp file, fsync, rename.
 func (s *FileStore) save() error {
 	dir := filepath.Dir(s.path)
 	if err := os.MkdirAll(dir, 0o700); err != nil {
@@ -380,28 +378,7 @@ func (s *FileStore) save() error {
 		return err
 	}
 	b = append(b, '\n')
-	tmp, err := os.CreateTemp(dir, ".keys-*.json")
-	if err != nil {
-		return err
-	}
-	name := tmp.Name()
-	defer os.Remove(name) // no-op once the rename has happened
-	if err := tmp.Chmod(0o600); err != nil {
-		tmp.Close()
-		return err
-	}
-	if _, err := tmp.Write(b); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Rename(name, s.path); err != nil {
+	if err := fsx.WriteFile(s.path, b, 0600); err != nil {
 		return err
 	}
 	if fi, err := os.Stat(s.path); err == nil {

--- a/internal/profile/install.go
+++ b/internal/profile/install.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/infercat/infercat/internal/fsx"
 	"github.com/infercat/infercat/internal/supervise"
 )
 
@@ -224,22 +225,12 @@ func SaveInstallation(dir string, in Installation) (string, error) {
 	if e = os.MkdirAll(filepath.Dir(path), 0700); e != nil {
 		return "", e
 	}
-	f, e := os.CreateTemp(filepath.Dir(path), ".manifest-")
-	if e != nil {
+	e = fsx.WriteFile(path, b, 0600)
+	// Preserve the existing returned name even when the final rename fails.
+	if _, rename := e.(*os.LinkError); e != nil && !rename {
 		return "", e
 	}
-	defer os.Remove(f.Name())
-	if _, e = f.Write(b); e == nil {
-		e = f.Sync()
-	}
-	ce := f.Close()
-	if e != nil {
-		return "", e
-	}
-	if ce != nil {
-		return "", ce
-	}
-	return name, os.Rename(f.Name(), path)
+	return name, e
 }
 func LoadInstallation(dir, name string) (Installation, error) {
 	var in Installation

--- a/internal/profile/runtime.go
+++ b/internal/profile/runtime.go
@@ -299,12 +299,7 @@ func (m *managed) loop() {
 			continue
 		}
 		if m.process != nil && m.process.Exited() {
-			m.process.Close()
-			m.process = nil
-			m.status.State = "backoff"
-			m.status.Healthy = false
-			m.retry = time.Now().Add(time.Second)
-			m.status.Restarts++
+			m.failedLocked(time.Second)
 		}
 		if m.process == nil && (m.member.Policy.Kind != "on-demand" || m.refs > 0) && !time.Now().Before(m.retry) {
 			m.startLocked()
@@ -323,12 +318,7 @@ func (m *managed) loop() {
 			} else {
 				m.failures++
 				if m.failures >= 3 && m.refs == 0 && m.process != nil {
-					m.process.Close()
-					m.process = nil
-					m.status.State = "backoff"
-					m.status.Healthy = false
-					m.retry = time.Now().Add(time.Second)
-					m.status.Restarts++
+					m.failedLocked(time.Second)
 				}
 			}
 			m.mu.Unlock()
@@ -382,4 +372,13 @@ func (m *managed) verify(ctx context.Context) error {
 func (r *Runtime) Owns(class string) bool {
 	m := r.members[class]
 	return m != nil && !m.installed.External && m.installed.Unavailable == ""
+}
+
+func (m *managed) failedLocked(wait time.Duration) {
+	m.process.Close()
+	m.process = nil
+	m.status.State = "backoff"
+	m.status.Healthy = false
+	m.retry = time.Now().Add(wait)
+	m.status.Restarts++
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/infercat/infercat/internal/fsx"
 )
 
 type snapshot struct {
@@ -92,32 +94,9 @@ func privateDir(path string) error {
 	return nil
 }
 func atomicWrite(path string, raw []byte) error {
-	f, err := os.CreateTemp(filepath.Dir(path), ".run-*")
-	if err != nil {
-		return err
-	}
-	name := f.Name()
-	defer os.Remove(name)
-	if _, err = f.Write(raw); err == nil {
-		err = f.Sync()
-	}
-	closeErr := f.Close()
-	if err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		return err
-	}
-	if err = os.Rename(name, path); err != nil {
-		return err
-	}
-	d, err := os.Open(filepath.Dir(path))
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	return d.Sync()
+	return fsx.WriteFileSyncDir(path, raw, 0600)
 }
+
 func (s *Store) load(key string) (*snapshot, error) {
 	if !safeID.MatchString(key) {
 		return nil, ErrInvalid

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -61,7 +61,6 @@ type KeyCounters struct {
 
 // Snapshot is what the admin API reads from the running gateway.
 type Snapshot interface {
-	Counters(keyID string) KeyCounters
 	AllCounters() map[string]KeyCounters
 	Queue() (inFlight, waiting int)
 }


### PR DESCRIPTION
Consolidate the CLI's exact option mirrors, invite JSON shape, table formatting, and model-call pluralization. Remove the unused warning hook, static gateway host name, unused key-store declarations, and the unused Counters interface requirement while retaining the Gateway method and injectable factories.

Six atomic-write copies now use `internal/fsx`, preserving final bytes/modes, caller directory creation, the `.run-*` cleanup prefix, and the run-store write seam with parent-directory sync. The two identical profile engine-death transitions share `failedLocked` with their one-second timing unchanged. CLI output is unchanged; console invite JSON uses the CLI's field order as approved.

Validation: `make check` CHECK OK, full Go race/vet green, web 490/490, host-compat 11/11, installer 18/18. Six base/candidate CLI invocations match exit status/stdout/stderr exactly. The fsx test covers both variants, replacement bytes/modes and failed-rename cleanup. Existing assertions are unchanged; only approved HostName→LiveHostName fixture setup moved. One initial cancellation timing miss passed three focused reruns and the final full gate without edits.

Base ad688b8; tip d252fa6. Source +103/-238 = **135 net lines removed**; tests +46/-5 = 41 net added; overall +149/-243 = **94 net removed**, 23 files. Patch SHA-256: `e77937a5dbe15d3377658101fb78f358bf8a0a7a47c55c442060e114789ab497`. CI run 34577693201 is in progress; full freeze sent to PM separately.
