### PR TITLE
173-b: Stabilize the image breaker retry timestamp fixture

### DIFF
--- a/internal/gateway/images_v3_test.go
+++ b/internal/gateway/images_v3_test.go
@@ -112,7 +112,9 @@ func TestSyncCompletionIsIndependentOfProbeCadence(t *testing.T) {
 }
 func TestInvalidOutputsTripBreakerAndExposeRetryTime(t *testing.T) {
 	h := imagesHarness(t, func(w http.ResponseWriter, r *http.Request) { io.WriteString(w, `{"data":[{"b64_json":"bad"}]}`) })
-	h.gw.imageBackoffBase = 10 * time.Millisecond
+	// The worker waits 0.5 s then 1 s (at least 2 s below each row bound);
+	// retry_at stays visible for 2 s instead of racing a 40 ms window.
+	h.gw.imageBackoffBase = 500 * time.Millisecond
 	rows := submittedImages(t, h.post("/v1/images/jobs", `{"prompts":["a","b","c","d"]}`))
 	for i, row := range rows {
 		r := waitImageJob(t, h, row.ID, runstate.Failed)


### PR DESCRIPTION
The image breaker fixture read `/me` after four failures with only a 40 ms remaining retry window, so scheduler delay could make `retry_at` disappear. Use the PM-ruled 500 ms test backoff base: the worker waits 0.5 s then 1 s (at least two seconds under each existing row bound), and the final observation window is two seconds. Production code and every assertion are unchanged.

Validation: 40/40 plain repetitions and 40/40 with `GOMAXPROCS=2 -race`, no failures or skips. Base also passed the same 40 stressed runs; the reported flake was not reproduced locally. Stressed package time increased from 6.138 s to 64.801 s across 40 repetitions: about 1.47 s extra per normal suite invocation. Plain package time: 63.806 s. The earlier one-second candidate is superseded.

Freeze: base ebbcd86; amended tip cb95b14. One test file, +3/-1 = 4 changed lines against ≤15; item 3 only of ticket 173. Patch SHA-256: `83281f3c4801a3251988363098e1227b02e195f2906a29d115e07a79e3a38e40`. Full report delivered to the PM through Embassy.
