### PR TITLE
Keep redirecting navigations outside the service worker

### DIFF
--- a/web/dev/returning-try-check.mjs
+++ b/web/dev/returning-try-check.mjs
@@ -1,0 +1,48 @@
+// With no URL, test built web/dist behind a real 302. With an origin, verify the deployed worker.
+// BROWSERS=chromium,webkit enables the local Safari regression without expanding CI's install.
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { resolve, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium, webkit } from 'playwright';
+const root = fileURLToPath(new URL('../dist/', import.meta.url));
+let server, origin = process.argv[2];
+if (!origin) {
+  server = createServer(async (req, res) => {
+    const path = new URL(req.url, 'http://localhost').pathname;
+    if (path === '/try') { res.writeHead(302, { Location: '/?from=try#ic2.fixture' }).end(); return; }
+    const file = resolve(root, '.' + (path === '/' ? '/index.html' : path));
+    if (!file.startsWith(root)) { res.writeHead(404).end(); return; }
+    try { const bytes = await readFile(path === '/sw.js' && process.env.SW_FIXTURE ? process.env.SW_FIXTURE : file); res.setHeader('Content-Type', ({'.html':'text/html','.js':'text/javascript','.css':'text/css','.json':'application/json'})[extname(file)] ?? 'application/octet-stream'); res.end(bytes); }
+    catch { res.writeHead(404).end(); }
+  });
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  origin = `http://127.0.0.1:${server.address().port}`;
+}
+let failed = false;
+try {
+  for (const name of (process.env.BROWSERS ?? 'chromium').split(',')) {
+    const engine = { chromium, webkit }[name]; assert.ok(engine, 'Supported browser required');
+    const browser = await engine.launch();
+    try {
+      const page = await browser.newPage();
+      await page.goto(new URL('/', origin).href);
+      await page.waitForFunction(() => window.navigator.serviceWorker.controller !== null, undefined, { timeout: 60000 });
+      let landed;
+      // The app consumes and clears the fragment; capture the committed navigation first.
+      page.on('framenavigated', frame => { if (frame === page.mainFrame()) { const url = new URL(frame.url()); if (url.searchParams.get('from') === 'try' && url.hash.startsWith('#ic')) landed = url; } });
+      await page.goto(new URL('/try', origin).href);
+      assert.ok(landed, 'redirect navigation carries attribution and invite before app consumption');
+      assert.equal(landed.origin, new URL(origin).origin, 'same-origin landing');
+      assert.equal(landed.searchParams.get('from'), 'try', 'redirect attribution');
+      assert.ok(landed.hash.startsWith('#ic'), 'redirect carries invite');
+      console.log(`RETURNING /try ${name} PASS (controlled page → redirect → invite)`);
+    } catch (error) {
+      // A real /try destination contains a credential: do not print browser URLs/errors.
+      failed = true; console.error(`RETURNING /try ${name} FAIL (worker navigation or redirect assertion)`);
+      if (server) console.error(String(error.message).split('\n')[0]);
+    } finally { await browser.close(); }
+  }
+} finally { if (server) await new Promise(resolve => server.close(resolve)); }
+if (failed) process.exitCode = 1;

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "fake-gateway": "node --experimental-strip-types dev/fake-gateway.ts",
     "screenshots": "node dev/screenshots.mjs",
     "brand": "node dev/brand.mjs",
-    "launch-check": "node dev/launch-check.mjs",
+    "launch-check": "node dev/launch-check.mjs && node dev/returning-try-check.mjs",
     "tunnel-check": "node dev/tunnel-check.mjs"
   },
   "dependencies": {

--- a/web/src/sw.test.ts
+++ b/web/src/sw.test.ts
@@ -80,3 +80,18 @@ it('late fetches cannot recreate a cache retired by a newer worker', async () =>
   await h.fetchEvent('/', 'navigate');
   expect([...h.stores.keys()]).toEqual([]);
 });
+
+it('leaves redirecting function navigations to the browser without respondWith', async () => {
+  const h = await harness(); await h.lifecycle('install'); h.network.mockClear();
+  h.network.mockResolvedValue(Response.redirect(`${origin}/?from=try`, 302));
+  for (const path of ['/try', '/try?source=qr', '/signup', '/console', '/future-function']) expect(h.fetchEvent(path, 'navigate')).toBeUndefined();
+  expect(h.network).not.toHaveBeenCalled();
+});
+it('never returns a redirected shell response as-is and retains the offline fallback', async () => {
+  const h = await harness(); await h.lifecycle('install');
+  const redirected = new Response('redirected HTML'); Object.defineProperty(redirected, 'redirected', { value: true });
+  h.network.mockResolvedValue(redirected);
+  expect(await (await h.fetchEvent('/index.html', 'navigate')!).text()).toBe(`network ${origin}/index.html`);
+  h.network.mockResolvedValue(Response.error());
+  expect(await (await h.fetchEvent('/', 'navigate')!).text()).toBe(`network ${origin}/index.html`);
+});

--- a/web/src/sw.ts
+++ b/web/src/sw.ts
@@ -33,8 +33,9 @@ worker.addEventListener('fetch', (event) => {
   const request = event.request, url = new URL(request.url);
   if (request.method !== 'GET' || url.origin !== worker.location.origin) return;
   if (request.mode === 'navigate') {
+    if (url.pathname !== '/' && url.pathname !== '/index.html') return;
     event.respondWith((async () => {
-      try { const response = await fetch(request); if (response.ok) return response; } catch { /* Offline shell. */ }
+      try { const response = await fetch(request); if (response.ok && !response.redirected && response.type !== 'opaqueredirect') return response; } catch { /* Offline shell. */ }
       // Never overwrite this version's HTML with a newer navigation response and older assets.
       return (await caches.match('/index.html', { cacheName: shellName })) ?? Response.error();
     })());


### PR DESCRIPTION
Returning visitors opening /try could lose its invite redirect because the service worker intercepted every navigation. It now handles only / and /index.html, retaining the offline-shell fallback, and never returns redirected shell responses as-is. Function routes remain browser-owned.

A returning-visitor regression installs the built worker, waits for controller ownership, then follows a real /try 302. It observes the redirect before the app clears the invite fragment. Chromium runs through launch-check in CI; WebKit is available through BROWSERS=chromium,webkit without adding a CI browser installation.

Validation: base worker fails the redirect assertion in both browsers; fixed worker passes both. Eight worker tests and all 485 web tests pass; typecheck/lint and make check are green. Post-deploy: BROWSERS=chromium,webkit node dev/returning-try-check.mjs https://infercat.ai, plus the existing live-assert.mjs /try check. No deployment performed by this branch.
