### PR TITLE
Wait for a settled worker before checking returning navigation

### DIFF
--- a/web/dev/returning-try-check.mjs
+++ b/web/dev/returning-try-check.mjs
@@ -29,6 +29,10 @@ try {
       const page = await browser.newPage();
       await page.goto(new URL('/', origin).href);
       await page.waitForFunction(() => window.navigator.serviceWorker.controller !== null, undefined, { timeout: 60000 });
+      await page.evaluate(() => window.navigator.serviceWorker.ready.then(() => undefined));
+      // Exercise a settled returning navigation, not the initial controller-claim race.
+      await page.reload();
+      await page.waitForFunction(() => window.navigator.serviceWorker.controller?.state === 'activated', undefined, { timeout: 60000 });
       let landed;
       // The app consumes and clears the fragment; capture the committed navigation first.
       page.on('framenavigated', frame => { if (frame === page.mainFrame()) { const url = new URL(frame.url()); if (url.searchParams.get('from') === 'try' && url.hash.startsWith('#ic')) landed = url; } });


### PR DESCRIPTION
Wait for serviceWorker.ready, reload once, and wait for an activated controller before opening /try. This makes the returning-visitor check run after initial worker activation settles.

Test-only: four added lines. make web and lint pass; the fixed worker passes Chromium and WebKit, while both still reject the original broken worker. No production worker or cache lifecycle changes.
